### PR TITLE
add enum SystemMonitoringService again - which was accidentally deleted

### DIFF
--- a/IBIS-IP_Enumerations_V2.2.xsd
+++ b/IBIS-IP_Enumerations_V2.2.xsd
@@ -241,6 +241,7 @@
 			<xs:enumeration value="TrainSetManagementService"/>
 			<xs:enumeration value="TicketValidationService"/>
 			<xs:enumeration value="HTMLDisplayService"/>
+			<xs:enumeration value="SystemMonitoringService"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="ServiceStateEnumeration">


### PR DESCRIPTION
add enum SystemMonitoringService again - which was accidentally deleted 