### PR TITLE
candidate 2.4 - update

### DIFF
--- a/IBIS-IP_AnalogRadioService_V2.4.xsd
+++ b/IBIS-IP_AnalogRadioService_V2.4.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<!-- Mit XMLSpy v2018 sp1 (x64) (http://www.altova.com) von Torsten Franke (IVU Traffic Technologies AG) bearbeitet -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="IBIS-IP_common_V2.3.xsd"/>
+	<!--==== AnalogueRadioService Operations ====-->
+	<xs:group name="AnalogRadioServiceOperations">
+		<xs:sequence>
+			<!--=====================================================-->
+			<!--=== Operation related to the AnalogRadioService  ===-->
+			<!--=====================================================-->
+			<!-- this operation is used to send a telegram from the Onboard unit to the analo radio device -->
+			<xs:element name="AnalogRadioService.SendTelegram" type="AnalogRadioService.RadioTelegramStructure"/>
+		</xs:sequence>
+	</xs:group>
+	<!--===================================================================================-->
+	<!--=== Defition of operation and data structures related to the AnalogRadioService ===-->
+	<!--===================================================================================-->
+	<!--=== SendTelegram Request ===-->
+	<xs:element name="AnalogRadioService.SendTelegram" type="AnalogRadioService.RadioTelegramStructure"/>
+	<xs:complexType name="AnalogRadioService.RadioTelegramStructure">
+		<xs:sequence>
+			<xs:element name="RawTelegram" type="IBIS-IP.string"/>
+			<xs:element name="AnalogChannel" type="IBIS-IP.unsignedInt"/>
+			<xs:element name="Bitrate" type="BitrateEnumeration"/>
+			<xs:element name="Repeats" type="IBIS-IP.unsignedInt" minOccurs="0"/>
+			<xs:element name="MaxRepeatInterval" type="IBIS-IP.unsignedInt" minOccurs="0"/>
+			<xs:element name="Transmitter" type="TransmitterStructure" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TransmitterStructure">
+		<xs:sequence>
+			<xs:element name="LeadTime" type="IBIS-IP.unsignedInt" minOccurs="0"/>
+			<xs:element name="HoldTime" type="IBIS-IP.unsignedInt" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="BitrateEnumeration">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="1200"/>
+			<xs:enumeration value="2400"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/IBIS-IP_CustomerInformationService_V2.4.xsd
+++ b/IBIS-IP_CustomerInformationService_V2.4.xsd
@@ -1,0 +1,239 @@
+<?xml version="1.0"?>
+<!-- Mit XMLSpy v2012 rel. 2 sp1 (http://www.altova.com) von Dirk Weißer (INIT GmbH) bearbeitet - inkl. CurrentDisplayContent 1:*-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="IBIS-IP_common_V2.4.xsd"/>
+	<xs:include schemaLocation="IBIS-IP_Enumerations_V2.2.xsd"/>
+	<!--==== CustomerInformationService Operations ====-->
+	<xs:group name="CustomerInformationServiceOperations">
+		<xs:sequence>
+			<xs:element name="CustomerInformationService.GetAllDataResponse" type="CustomerInformationService.GetAllDataResponseStructure"/>
+			<xs:element name="CustomerInformationService.GetCurrentAnnouncementResponse" type="CustomerInformationService.GetCurrentAnnouncementResponseStructure"/>
+			<xs:element name="CustomerInformationService.GetCurrentConnectionInformationResponse" type="CustomerInformationService.GetCurrentConnectionInformationResponseStructure"/>
+			<xs:element name="CustomerInformationService.GetCurrentDisplayContentResponse" type="CustomerInformationService.GetCurrentDisplayContentResponseStructure"/>
+			<xs:element name="CustomerInformationService.GetCurrentStopPointResponse" type="CustomerInformationService.GetCurrentStopPointResponseStructure"/>
+			<xs:element name="CustomerInformationService.GetCurrentStopIndexResponse" type="CustomerInformationService.GetCurrentStopIndexResponseStructure"/>
+			<xs:element name="CustomerInformationService.GetTripDataResponse" type="CustomerInformationService.GetTripDataResponseStructure"/>
+			<xs:element name="CustomerInformationService.GetVehicleDataResponse" type="CustomerInformationService.GetVehicleDataResponseStructure"/>
+			<xs:element name="CustomerInformationService.RetrievePartialStopSequenceRequest" type="CustomerInformationService.RetrievePartialStopSequenceRequestStructure"/>
+			<xs:element name="CustomerInformationService.RetrievePartialStopSequenceResponse" type="CustomerInformationService.RetrievePartialStopSequenceResponseStructure"/>
+		</xs:sequence>
+	</xs:group>
+	<!--=== ServiceDefinitions ===-->
+	<!--++ GetAllData ++-->
+	<xs:element name="CustomerInformationService.GetAllDataResponse" type="CustomerInformationService.GetAllDataResponseStructure"/>
+	<xs:complexType name="CustomerInformationService.GetAllDataResponseStructure">
+		<xs:choice>
+			<xs:element name="AllData" type="CustomerInformationService.AllData"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CustomerInformationService.AllData">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="VehicleRef" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="DefaultLanguage" type="IBIS-IP.language"/>
+			<xs:element name="TripInformation" type="TripInformationStructure" minOccurs="0" maxOccurs="2">
+				<xs:annotation>
+					<xs:documentation>if vehicle is not on a trip and no tripinformation is available occurrence typically is 0
+									if vehicle is on a trip or knows the next trip to run  occurrence typically is 1
+									if vehicle is on a trip and also knows the subsequent trip that info can be provided in the second TripInformation so occurrence is 2</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CurrentStopIndex" type="IBIS-IP.int">
+				<xs:annotation>
+					<xs:documentation>Index of the Stoppoint in the Stopsequence, which is the next Stop</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:group ref="VehicleInformationGroup"/>
+			<xs:element name="GlobalDisplayContent" type="DisplayContentStructure" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Global display content - this content should be used if no stop specific display content is available
+					please make sure that the global display content and the stop specific content are provided for the same DisplayContentRefs. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ CurrentAnnouncement ++-->
+	<xs:element name="CustomerInformationService.GetCurrentAnnouncementResponse" type="CustomerInformationService.GetCurrentAnnouncementResponseStructure"/>
+	<xs:complexType name="CustomerInformationService.GetCurrentAnnouncementResponseStructure">
+		<xs:choice>
+			<xs:element name="CurrentAnnouncementData" type="CustomerInformationService.CurrentAnnouncementData"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CustomerInformationService.CurrentAnnouncementData">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="CurrentAnnouncement" type="AnnouncementStructure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ CurrentConnection ++-->
+	<xs:element name="CustomerInformationService.GetCurrentConnectionInformationResponse" type="CustomerInformationService.GetCurrentConnectionInformationResponseStructure"/>
+	<xs:complexType name="CustomerInformationService.GetCurrentConnectionInformationResponseStructure">
+		<xs:choice>
+			<xs:element name="CurrentConnectionData" type="CustomerInformationService.CurrentConnectionInformationData"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CustomerInformationService.CurrentConnectionInformationData">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="CurrentConnection" type="ConnectionStructure" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ CurrentDisplayContent ++-->
+	<xs:element name="CustomerInformationService.GetCurrentDisplayContentResponse" type="CustomerInformationService.GetCurrentDisplayContentResponseStructure"/>
+	<xs:complexType name="CustomerInformationService.GetCurrentDisplayContentResponseStructure">
+		<xs:choice>
+			<xs:element name="CurrentDisplayContentData" type="CustomerInformationService.CurrentDisplayContentData"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CustomerInformationService.CurrentDisplayContentData">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="CurrentDisplayContent" type="DisplayContentStructure" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ CurrentStopPoint ++-->
+	<xs:element name="CustomerInformationService.GetCurrentStopPointResponse" type="CustomerInformationService.GetCurrentStopPointResponseStructure"/>
+	<xs:complexType name="CustomerInformationService.GetCurrentStopPointResponseStructure">
+		<xs:choice>
+			<xs:element name="CurrentStopPointData" type="CustomerInformationService.CurrentStopPointData"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CustomerInformationService.CurrentStopPointData">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="CurrentStopPoint" type="StopInformationStructure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ CurrentStopIndex ++-->
+	<xs:element name="CustomerInformationService.GetCurrentStopIndexResponse" type="CustomerInformationService.GetCurrentStopIndexResponseStructure"/>
+	<xs:complexType name="CustomerInformationService.GetCurrentStopIndexResponseStructure">
+		<xs:choice>
+			<xs:element name="CurrentStopIndexData" type="CustomerInformationService.CurrentStopIndexData"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CustomerInformationService.CurrentStopIndexData">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="CurrentStopIndex" type="IBIS-IP.int"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ TripData ++-->
+	<xs:element name="CustomerInformationService.GetTripDataResponse" type="CustomerInformationService.GetTripDataResponseStructure"/>
+	<xs:complexType name="CustomerInformationService.GetTripDataResponseStructure">
+		<xs:choice>
+			<xs:element name="TripData" type="CustomerInformationService.TripData"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CustomerInformationService.TripData">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="VehicleRef" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="DefaultLanguage" type="IBIS-IP.language"/>
+			<xs:element name="TripInformation" type="TripInformationStructure"/>
+			<xs:element name="CurrentStopIndex" type="IBIS-IP.int">
+				<xs:annotation>
+					<xs:documentation>Index of the Stoppoint in the Stopsequence, which is the next Stop in the first trip</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ VehicleData ++-->
+	<xs:element name="CustomerInformationService.GetVehicleDataResponse" type="CustomerInformationService.GetVehicleDataResponseStructure"/>
+	<xs:complexType name="CustomerInformationService.GetVehicleDataResponseStructure">
+		<xs:choice>
+			<xs:element name="VehicleData" type="CustomerInformationService.VehicleData"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CustomerInformationService.VehicleData">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="VehicleRef" type="IBIS-IP.NMTOKEN"/>
+			<xs:group ref="VehicleInformationGroup"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--==== RetrievePartialStopSequence ====-->
+	<xs:element name="CustomerInformationService.RetrievePartialStopSequenceRequest" type="CustomerInformationService.RetrievePartialStopSequenceRequestStructure"/>
+	<xs:complexType name="CustomerInformationService.RetrievePartialStopSequenceRequestStructure">
+		<xs:sequence>
+			<xs:element name="StartingStopIndex" type="IBIS-IP.int"/>
+			<xs:element name="NumberOfStopPoints" type="IBIS-IP.int"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="CustomerInformationService.RetrievePartialStopSequenceResponse" type="CustomerInformationService.RetrievePartialStopSequenceResponseStructure"/>
+	<xs:complexType name="CustomerInformationService.RetrievePartialStopSequenceResponseStructure">
+		<xs:choice>
+			<xs:element name="PartialStopSequenceData" type="CustomerInformationService.PartialStopSequenceData"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CustomerInformationService.PartialStopSequenceData">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="StopSequence" type="StopSequenceStructure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--==== Group Definitions ====-->
+	<xs:group name="VehicleInformationGroup">
+		<xs:sequence>
+			<xs:element name="RouteDeviation" type="RouteDeviationEnumeration">
+				<xs:annotation>
+					<xs:documentation>Contains the information about route deviation</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DoorState" type="DoorOpenStateEnumeration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Information on DoorState</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="InPanic" type="IBIS-IP.boolean" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Is the Emergency-Button pressed?</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="VehicleStopRequested" type="IBIS-IP.boolean" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Is the Stop-Button inside the vehicle pressed? </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ExitSide" type="ExitSideEnumeration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Defines the exit side     		</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="MovingDirectionForward" type="IBIS-IP.boolean" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Gives information, if the vehicle is moving forward, default value is "true"</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="VehicleMode" type="VehicleModeEnumeration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>DEPRECATED, is of type VehicleModeEnumeration. MyOwnVehicleMode SHOULD BE USED INSTEAD</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="MyOwnVehicleMode" type="NetexMode" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Mode- and Submode information vehicle I am in - in accordance with Netex</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="SpeakerActive" type="IBIS-IP.boolean" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Gives information, if the loud speaker is activated for a passenger announcement</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="StopInformationActive" type="IBIS-IP.boolean" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Gives information, if the stopInformation inside the vehicle is in active or in passiv state (intentionally, e.g. due to "route left)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="TripState" type="TripStateEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:group>
+</xs:schema>

--- a/IBIS-IP_DeviceManagementService_V2.3.xsd
+++ b/IBIS-IP_DeviceManagementService_V2.3.xsd
@@ -1,0 +1,463 @@
+<?xml version="1.0"?>
+<!-- Mit XMLSpy v2012 rel. 2 sp1 (http://www.altova.com) von Dirk Weißer (INIT GmbH) bearbeitet -->
+<!--  IVU Traffic Technologies AG, Carsten Weise -->
+<!-- Mit XMLSpy v2018 rel. 2  (http://www.altova.com) von Bernd Schubert (iris-GmbH) bearbeitet, IBIS-IP 2.1 -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="IBIS-IP_common_V2.3.xsd"/>
+	<xs:include schemaLocation="IBIS-IP_Enumerations_V2.2.xsd"/>
+	<!--==== DeviceManagementService Operations====-->
+	<xs:group name="DeviceManagementServiceGroup">
+		<xs:sequence>
+			<xs:element name="DeviceManagementService.GetDeviceInformationRequest"/>
+			<xs:element name="DeviceManagementService.GetDeviceInformationResponse" type="DeviceManagementService.GetDeviceInformationResponseStructure"/>
+			<xs:element name="DeviceManagementService.SubscribeDeviceInformationRequest" type="SubscribeRequestStructure"/>
+			<xs:element name="DeviceManagementService.SubscribeDeviceInformationResponse" type="SubscribeResponseStructure"/>
+			<xs:element name="DeviceManagementService.UnsubscribeDeviceInformationRequest" type="UnsubscribeRequestStructure"/>
+			<xs:element name="DeviceManagementService.UnsubscribeDeviceInformationResponse" type="UnsubscribeResponseStructure"/>
+			<xs:element name="DeviceManagementService.GetAllSubdeviceInformationRequest"/>
+			<xs:element name="DeviceManagementService.GetAllSubdeviceInformationResponse" type="DeviceManagementService.GetAllSubdeviceInformationResponseStructure"/>
+			<xs:element name="DeviceManagementService.SubscribeAllSubdeviceInformationRequest" type="SubscribeRequestStructure"/>
+			<xs:element name="DeviceManagementService.SubscribeAllSubdeviceInformationResponse" type="SubscribeResponseStructure"/>
+			<xs:element name="DeviceManagementService.UnsubscribeAllSubdeviceInformationRequest" type="UnsubscribeRequestStructure"/>
+			<xs:element name="DeviceManagementService.UnsubscribeAllSubdeviceInformationResponse" type="UnsubscribeResponseStructure"/>
+			<xs:element name="DeviceManagementService.GetDeviceConfigurationRequest"/>
+			<xs:element name="DeviceManagementService.GetDeviceConfigurationResponse" type="DeviceManagementService.GetDeviceConfigurationResponseStructure"/>
+			<xs:element name="DeviceManagementService.GetDeviceStatusRequest"/>
+			<xs:element name="DeviceManagementService.GetDeviceStatusResponse" type="DeviceManagementService.GetDeviceStatusResponseStructure"/>
+			<xs:element name="DeviceManagementService.SubscribeDeviceStatusRequest" type="SubscribeRequestStructure"/>
+			<xs:element name="DeviceManagementService.SubscribeDeviceStatusResponse" type="SubscribeResponseStructure"/>
+			<xs:element name="DeviceManagementService.UnsubscribeDeviceStatusRequest" type="UnsubscribeRequestStructure"/>
+			<xs:element name="DeviceManagementService.UnsubscribeDeviceStatusResponse" type="UnsubscribeResponseStructure"/>
+			<xs:element name="DeviceManagementService.GetDeviceStatusInformationRequest"/>
+			<xs:element name="DeviceManagementService.GetDeviceStatusInformationResponse" type="DeviceManagementService.GetDeviceStatusInformationResponseStructure"/>
+			<xs:element name="DeviceManagementService.SubscribeDeviceStatusInformationRequest" type="SubscribeRequestStructure"/>
+			<xs:element name="DeviceManagementService.SubscribeDeviceStatusInformationResponse" type="SubscribeResponseStructure"/>
+			<xs:element name="DeviceManagementService.UnsubscribeDeviceStatusInformationRequest" type="UnsubscribeRequestStructure"/>
+			<xs:element name="DeviceManagementService.UnsubscribeDeviceStatusInformationResponse" type="UnsubscribeResponseStructure"/>
+			<xs:element name="DeviceManagementService.GetAllSubdeviceStatusInformationRequest"/>
+			<xs:element name="DeviceManagementService.GetAllSubdeviceStatusInformationResponse" type="DeviceManagementService.GetAllSubdeviceStatusInformationResponseStructure"/>
+			<xs:element name="DeviceManagementService.SubscribeAllSubdeviceStatusInformationRequest" type="SubscribeRequestStructure"/>
+			<xs:element name="DeviceManagementService.SubscribeAllSubdeviceStatusInformationResponse" type="SubscribeResponseStructure"/>
+			<xs:element name="DeviceManagementService.UnsubscribeAllSubdeviceStatusInformationRequest" type="UnsubscribeRequestStructure"/>
+			<xs:element name="DeviceManagementService.UnsubscribeAllSubdeviceStatusInformationResponse" type="UnsubscribeResponseStructure"/>
+			<xs:element name="DeviceManagementService.GetDeviceErrorMessagesRequest"/>
+			<xs:element name="DeviceManagementService.GetDeviceErrorMessagesResponse" type="DeviceManagementService.GetDeviceErrorMessagesResponseStructure"/>
+			<xs:element name="DeviceManagementService.SubscribeDeviceErrorMessagesRequest" type="SubscribeRequestStructure"/>
+			<xs:element name="DeviceManagementService.SubscribeDeviceErrorMessagesResponse" type="SubscribeResponseStructure"/>
+			<xs:element name="DeviceManagementService.UnsubscribeDeviceErrorMessagesRequest" type="UnsubscribeRequestStructure"/>
+			<xs:element name="DeviceManagementService.UnsubscribeDeviceErrorMessagesResponse" type="UnsubscribeResponseStructure"/>
+			<xs:element name="DeviceManagementService.GetAllSubdeviceErrorMessagesRequest"/>
+			<xs:element name="DeviceManagementService.GetAllSubdeviceErrorMessagesResponse" type="DeviceManagementService.GetAllSubdeviceErrorMessagesResponseStructure"/>
+			<xs:element name="DeviceManagementService.SubscribeAllSubdeviceErrorMessagesRequest" type="SubscribeRequestStructure"/>
+			<xs:element name="DeviceManagementService.SubscribeAllSubdeviceErrorMessagesResponse" type="SubscribeResponseStructure"/>
+			<xs:element name="DeviceManagementService.UnsubscribeAllSubdeviceErrorMessagesRequest" type="UnsubscribeRequestStructure"/>
+			<xs:element name="DeviceManagementService.UnsubscribeAllSubdeviceErrorMessagesResponse" type="UnsubscribeResponseStructure"/>
+			<xs:element name="DeviceManagementService.GetServiceInformationRequest"/>
+			<xs:element name="DeviceManagementService.GetServiceInformationResponse" type="DeviceManagementService.GetServiceInformationResponseStructure"/>
+			<xs:element name="DeviceManagementService.SubscribeServiceInformationRequest" type="SubscribeRequestStructure"/>
+			<xs:element name="DeviceManagementService.SubscribeServiceInformationResponse" type="SubscribeResponseStructure"/>
+			<xs:element name="DeviceManagementService.UnsubscribeServiceInformationRequest" type="UnsubscribeRequestStructure"/>
+			<xs:element name="DeviceManagementService.UnsubscribeServiceInformationResponse" type="UnsubscribeResponseStructure"/>
+			<xs:element name="DeviceManagementService.GetServiceStatusRequest"/>
+			<xs:element name="DeviceManagementService.GetServiceStatusResponse" type="DeviceManagementService.GetServiceStatusResponseStructure"/>
+			<xs:element name="DeviceManagementService.SubscribeServiceStatusRequest" type="SubscribeRequestStructure"/>
+			<xs:element name="DeviceManagementService.SubscribeServiceStatusResponse" type="SubscribeResponseStructure"/>
+			<xs:element name="DeviceManagementService.UnsubscribeServiceStatusRequest" type="UnsubscribeRequestStructure"/>
+			<xs:element name="DeviceManagementService.UnsubscribeServiceStatusResponse" type="UnsubscribeResponseStructure"/>
+			<xs:element name="DeviceManagementService.RestartDeviceRequest"/>
+			<xs:element name="DeviceManagementService.RestartDeviceResponse" type="DataAcceptedResponseStructure"/>
+			<xs:element name="DeviceManagementService.InstallUpdateRequest" type="DeviceManagementService.InstallUpdateRequestStructure"/>
+			<xs:element name="DeviceManagementService.InstallUpdateResponse" type="DeviceManagementService.InstallUpdateResponseStructure"/>
+			<xs:element name="DeviceManagementService.RetrieveUpdateStateRequest" type="DeviceManagementService.RetrieveUpdateStateRequestStructure"/>
+			<xs:element name="DeviceManagementService.RetrieveUpdateStateResponse" type="DeviceManagementService.RetrieveUpdateStateResponseStructure"/>
+			<xs:element name="DeviceManagementService.GetUpdateHistoryRequest"/>
+			<xs:element name="DeviceManagementService.GetUpdateHistoryResponse" type="DeviceManagementService.GetUpdateHistoryResponseStructure"/>
+			<xs:element name="DeviceManagementService.FinalizeUpdateRequest" type="DeviceManagementService.FinalizeUpdateRequestStructure"/>
+			<xs:element name="DeviceManagementService.FinalizeUpdateResponse" type="DeviceManagementService.FinalizeUpdateResponseStructure"/>
+			<xs:element name="DeviceManagementService.FinalizeAllPendingUpdatesRequest"/>
+			<xs:element name="DeviceManagementService.FinalizeAllPendingUpdatesResponse" type="DataAcceptedResponseStructure"/>
+		</xs:sequence>
+	</xs:group>
+	<!--==== Service Definitions ====-->
+	<!--++ GetDeviceInformation ++-->
+	<xs:element name="DeviceManagementService.GetDeviceInformationResponse" type="DeviceManagementService.GetDeviceInformationResponseStructure"/>
+	<xs:complexType name="DeviceManagementService.GetDeviceInformationResponseStructure">
+		<xs:choice>
+			<xs:element name="DeviceManagementService.GetDeviceInformationResponseData" type="DeviceManagementService.GetDeviceInformationResponseDataStructure"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="DeviceManagementService.GetDeviceInformationResponseDataStructure">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="DeviceInformation" type="DeviceInformationStructure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ GetAllSubdeviceInformation ++-->
+	<xs:element name="DeviceManagementService.GetAllSubdeviceInformationResponse" type="DeviceManagementService.GetAllSubdeviceInformationResponseStructure"/>
+	<xs:complexType name="DeviceManagementService.GetAllSubdeviceInformationResponseStructure">
+		<xs:choice>
+			<xs:element name="DeviceManagementService.GetAllSubdeviceInformationResponseData" type="DeviceManagementService.GetAllSubdeviceInformationResponseDataStructure"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="DeviceManagementService.GetAllSubdeviceInformationResponseDataStructure">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="SubdeviceInformationList" minOccurs="1">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="SubdeviceInformation" type="SubdeviceInformationStructure" minOccurs="1" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ GetDeviceConfiguration ++-->
+	<xs:element name="DeviceManagementService.GetDeviceConfigurationResponse" type="DeviceManagementService.GetDeviceConfigurationResponseStructure"/>
+	<xs:complexType name="DeviceManagementService.GetDeviceConfigurationResponseStructure">
+		<xs:choice>
+			<xs:element name="DeviceManagementService.GetDeviceConfigurationResponseData" type="DeviceManagementService.GetDeviceConfigurationResponseDataStructure"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="DeviceManagementService.GetDeviceConfigurationResponseDataStructure">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="DeviceID" type="IBIS-IP.int"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ GetDeviceStatus ++-->
+	<xs:element name="DeviceManagementService.GetDeviceStatusResponse" type="DeviceManagementService.GetDeviceStatusResponseStructure"/>
+	<xs:complexType name="DeviceManagementService.GetDeviceStatusResponseStructure">
+		<xs:choice>
+			<xs:element name="DeviceManagementService.GetDeviceStatusResponseData" type="DeviceManagementService.GetDeviceStatusResponseDataStructure"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="DeviceManagementService.GetDeviceStatusResponseDataStructure">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="DeviceState" type="DeviceStateEnumeration"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ GetDeviceStatusInformation ++-->
+	<xs:element name="DeviceManagementService.GetDeviceStatusInformationResponse" type="DeviceManagementService.GetDeviceStatusInformationResponseStructure"/>
+	<xs:complexType name="DeviceManagementService.GetDeviceStatusInformationResponseStructure">
+		<xs:choice>
+			<xs:element name="DeviceManagementService.GetDeviceStatusInformationResponseData" type="DeviceManagementService.GetDeviceStatusInformationResponseDataStructure"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="DeviceManagementService.GetDeviceStatusInformationResponseDataStructure">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="DeviceStatusInformation" type="DeviceStatusInformationStructure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ GetAllSubdeviceStatusInformation ++-->
+	<xs:element name="DeviceManagementService.GetAllSubdeviceStatusInformationResponse" type="DeviceManagementService.GetAllSubdeviceStatusInformationResponseStructure"/>
+	<xs:complexType name="DeviceManagementService.GetAllSubdeviceStatusInformationResponseStructure">
+		<xs:choice>
+			<xs:element name="DeviceManagementService.GetAllSubdeviceStatusInformationResponseData" type="DeviceManagementService.GetAllSubdeviceStatusInformationResponseDataStructure"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="DeviceManagementService.GetAllSubdeviceStatusInformationResponseDataStructure">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="SubdeviceStatusInformationList" minOccurs="1">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="SubdeviceStatusInformation" type="SubdeviceStatusInformationStructure" minOccurs="1" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ GetDeviceErrorMessages ++-->
+	<xs:element name="DeviceManagementService.GetDeviceErrorMessagesResponse" type="DeviceManagementService.GetDeviceErrorMessagesResponseStructure"/>
+	<xs:complexType name="DeviceManagementService.GetDeviceErrorMessagesResponseStructure">
+		<xs:choice>
+			<xs:element name="DeviceManagementService.GetDeviceErrorMessagesResponseData" type="DeviceManagementService.GetDeviceErrorMessagesResponseDataStructure"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="DeviceManagementService.GetDeviceErrorMessagesResponseDataStructure">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="ErrorMessage" type="MessageStructure" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Warnings and errors only, no state messages</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ GetAllSubdeviceErrorMessages ++-->
+	<xs:element name="DeviceManagementService.GetAllSubdeviceErrorMessagesResponse" type="DeviceManagementService.GetAllSubdeviceErrorMessagesResponseStructure"/>
+	<xs:complexType name="DeviceManagementService.GetAllSubdeviceErrorMessagesResponseStructure">
+		<xs:choice>
+			<xs:element name="DeviceManagementService.GetAllSubdeviceErrorMessagesResponseData" type="DeviceManagementService.GetAllSubdeviceErrorMessagesResponseDataStructure"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="DeviceManagementService.GetAllSubdeviceErrorMessagesResponseDataStructure">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="SubdeviceErrorMessagesList" minOccurs="1">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="SubdeviceErrorMessages" type="SubdeviceErrorMessagesStructure" minOccurs="1" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ GetServiceInformation ++-->
+	<xs:element name="DeviceManagementService.GetServiceInformationResponse" type="DeviceManagementService.GetServiceInformationResponseStructure"/>
+	<xs:complexType name="DeviceManagementService.GetServiceInformationResponseStructure">
+		<xs:choice>
+			<xs:element name="DeviceManagementService.GetServiceInformationResponseData" type="DeviceManagementService.GetServiceInformationResponseDataStructure"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="DeviceManagementService.GetServiceInformationResponseDataStructure">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="ServiceInformationList" type="ServiceInformationListStructure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ GetServiceStatus ++-->
+	<xs:element name="DeviceManagementService.GetServiceStatusResponse" type="DeviceManagementService.GetServiceStatusResponseStructure"/>
+	<xs:complexType name="DeviceManagementService.GetServiceStatusResponseStructure">
+		<xs:choice>
+			<xs:element name="DeviceManagementService.GetServiceStatusResponseData" type="DeviceManagementService.GetServiceStatusResponseDataStructure"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="DeviceManagementService.GetServiceStatusResponseDataStructure">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="ServiceSpecificationWithStateList" type="ServiceSpecificationWithStateListStructure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ RestartDevice ++-->
+	<xs:element name="DeviceManagementService.RestartDeviceResponse" type="DataAcceptedResponseStructure"/>
+	<!--++ InstallUpdate ++-->
+	<xs:complexType name="DeviceManagementService.InstallUpdateRequestStructure">
+		<xs:sequence>
+			<xs:element name="UpdateID" type="IBIS-IP.NMTOKEN">
+				<xs:annotation><xs:documentation>Unique id generated by the controller to identify an update job</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="UpdateTimestamp" type="IBIS-IP.dateTime">
+				<xs:annotation><xs:documentation>Timestamp used for GetUpdateHistory and RetrieveUpdateState responses and for logging</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="UpdateURL" type="IBIS-IP.anyURI">
+				<xs:annotation><xs:documentation>URL from which the device shall download the update file</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="UpdateFileChecksum" type="ChecksumStructure" minOccurs="0">
+				<xs:annotation><xs:documentation>Optional checksum of update file</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="UpdateFileSize" type="IBIS-IP.unsignedLong" minOccurs="0">
+				<xs:annotation><xs:documentation>Optional size of update file</xs:documentation></xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DeviceManagementService.InstallUpdateResponseStructure">
+		<xs:choice>
+			<xs:element name="UpdateAccept" type="UpdateAcceptEnumeration"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<!--++ RetrieveUpdateState ++-->
+	<xs:complexType name="DeviceManagementService.RetrieveUpdateStateRequestStructure">
+		<xs:sequence>
+			<xs:element name="UpdateID" type="IBIS-IP.NMTOKEN"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DeviceManagementService.RetrieveUpdateStateResponseStructure">
+		<xs:choice>
+			<xs:element name="UpdateStateData" type="DeviceManagementService.UpdateStateDataStructure"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="DeviceManagementService.UpdateStateDataStructure">
+		<xs:sequence>
+			<xs:element name="UpdateID" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="UpdateTimestamp" type="IBIS-IP.dateTime">
+				<xs:annotation><xs:documentation>Timestamp given by operation InstallUpdate</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="UpdateStatus" type="UpdateStatusEnumeration">
+				<xs:annotation><xs:documentation>Current status of update</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="UpdateDetails" type="IBIS-IP.string" minOccurs="0">
+				<xs:annotation><xs:documentation>Optional device specific update log</xs:documentation></xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ GetUpdateHistory ++-->
+	<xs:complexType name="DeviceManagementService.GetUpdateHistoryResponseStructure">
+		<xs:choice>
+			<xs:element name="UpdateHistory" type="DeviceManagementService.UpdateHistoryStructure"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="DeviceManagementService.UpdateHistoryStructure">
+		<xs:sequence>
+			<xs:element name="UpdateHistoryEntry" type="DeviceManagementService.UpdateHistoryEntryStructure" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation><xs:documentation>Minimum requirement for any device allowing updates is an update history depth of 1, 
+					i.e. history shall contain at least the last update performed (regardless of its result), if there was any.</xs:documentation></xs:annotation> 
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DeviceManagementService.UpdateHistoryEntryStructure">
+		<xs:sequence>
+			<xs:element name="UpdateID" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="UpdateTimestamp" type="IBIS-IP.dateTime">
+				<xs:annotation><xs:documentation>Timestamp given by operation InstallUpdate</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="UpdateURL" type="IBIS-IP.anyURI">
+				<xs:annotation><xs:documentation>URL from which the device downloaded the update file</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="UpdateStatus" type="UpdateStatusEnumeration">
+				<xs:annotation><xs:documentation>Status of update. Typically final status (InstallationSuccessfull or InstallationFailed)</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="DataVersionList" type="DataVersionListStructure" minOccurs="0">
+				<xs:annotation><xs:documentation>Optional list of updated components</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="UpdateDetails" type="IBIS-IP.string" minOccurs="0">
+				<xs:annotation><xs:documentation>Optional device specific update log</xs:documentation></xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<!--++ FinalizeUpdate ++-->
+	<xs:complexType name="DeviceManagementService.FinalizeUpdateRequestStructure">
+		<xs:sequence>
+			<xs:element name="UpdateID" type="IBIS-IP.NMTOKEN"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DeviceManagementService.FinalizeUpdateResponseStructure">
+		<xs:choice>
+			<xs:element name="UpdateStatus" type="UpdateStatusEnumeration">
+				<xs:annotation><xs:documentation>Status of update on its finalization</xs:documentation></xs:annotation>
+			</xs:element>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>	
+	<!--++ FinalizeAllPendingUpdates ++-->
+	<xs:element name="DeviceManagementService.FinalizeAllPendingUpdatesResponse" type="DataAcceptedResponseStructure"/>
+	<!--++ Enumerations ++-->
+	<xs:simpleType name="ChecksumTypeEnumeration">
+		<xs:annotation>
+			<xs:documentation>Types of checksum</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CRC32"><xs:annotation><xs:documentation>Cyclic redundancy check, 32-bit</xs:documentation></xs:annotation></xs:enumeration>
+			<xs:enumeration value="MD5"><xs:annotation><xs:documentation>Message digest algorithm 5, 128-bit</xs:documentation></xs:annotation></xs:enumeration>
+			<xs:enumeration value="SHA256"><xs:annotation><xs:documentation>Secure hash algorithm, 256-bit</xs:documentation></xs:annotation></xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UpdateAcceptEnumeration">
+		<xs:annotation>
+			<xs:documentation>Information about the result of InstallUpdate</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="UpdateAccepted"><xs:annotation><xs:documentation>Update will be performed</xs:documentation></xs:annotation></xs:enumeration>
+			<xs:enumeration value="URLTypeUnknown"><xs:annotation><xs:documentation>URL type has been rejected, e.g. FTP may not supported by some devices</xs:documentation></xs:annotation></xs:enumeration>
+			<xs:enumeration value="NoUpdatesAllowed"><xs:annotation><xs:documentation>No updates are possible</xs:documentation></xs:annotation></xs:enumeration>
+			<xs:enumeration value="ToBePostponed"><xs:annotation><xs:documentation>Update has to be postponed</xs:documentation></xs:annotation></xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="UpdateStatusEnumeration">
+		<xs:annotation>
+			<xs:documentation>Information about the current status of update</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="UpdateRunning"><xs:annotation><xs:documentation>Update in progress</xs:documentation></xs:annotation></xs:enumeration>
+			<xs:enumeration value="DeviceRestartRequired"><xs:annotation><xs:documentation>Device has to be restarted by operation RestartDevice</xs:documentation></xs:annotation></xs:enumeration>
+			<xs:enumeration value="DownloadUpdateFileFailed"><xs:annotation><xs:documentation>Specified update file could not be downloaded from URL</xs:documentation></xs:annotation></xs:enumeration>
+			<xs:enumeration value="UpdateFileCorrupted"><xs:annotation><xs:documentation>Specified update file is not usable</xs:documentation></xs:annotation></xs:enumeration>
+			<xs:enumeration value="UpdateNotNecessary"><xs:annotation><xs:documentation>State of device firmware already as required</xs:documentation></xs:annotation></xs:enumeration>
+			<xs:enumeration value="InstallationFailed"><xs:annotation><xs:documentation>Update failed e.g. due to memory write error</xs:documentation></xs:annotation></xs:enumeration>
+			<xs:enumeration value="InstallationSuccessful"><xs:annotation><xs:documentation>Update successfully completed</xs:documentation></xs:annotation></xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--++ Structures ++-->
+	<xs:complexType name="SubdeviceInformationStructure">
+		<xs:annotation>
+			<xs:documentation>Information on named subdevice</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="SubdeviceName" type="IBIS-IP.string">
+				<xs:annotation>
+					<xs:documentation>Used to identify subdevice</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DeviceInformation" type="DeviceInformationStructure">
+				<xs:annotation>
+					<xs:documentation>Information on subdevice</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DeviceStatusStructure">
+		<xs:sequence>
+			<xs:element name="DeviceStatusName" type="IBIS-IP.string"/>
+			<xs:element name="DeviceStatusFlag" type="IBIS-IP.boolean"/>
+			<xs:element name="DeviceStatusImpact" type="DeviceStateEnumeration"> </xs:element>
+			<xs:element name="DeviceStatusPriority" type="IBIS-IP.int"></xs:element>			
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DeviceStatusInformationStructure">
+		<xs:sequence>
+			<xs:element name="DeviceState" type="DeviceStateEnumeration"/>
+			<xs:element name="DeviceStatusList" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="DeviceStatus" type="DeviceStatusStructure" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SubdeviceStatusInformationStructure">
+		<xs:annotation>
+			<xs:documentation>Status information of named subdevice</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="SubdeviceName" type="IBIS-IP.string">
+				<xs:annotation>
+					<xs:documentation>Used to identify subdevice</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DeviceStatusInformation" type="DeviceStatusInformationStructure">
+				<xs:annotation>
+					<xs:documentation>Status information of subdevice</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SubdeviceErrorMessagesStructure">
+		<xs:annotation>
+			<xs:documentation>Error messages of named subdevice</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="SubdeviceName" type="IBIS-IP.string">
+				<xs:annotation>
+					<xs:documentation>Used to identify subdevice</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ErrorMessage" type="MessageStructure" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Warnings and errors only, no state messages</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ChecksumStructure">
+		<xs:sequence>
+			<xs:element name="ChecksumType" type="ChecksumTypeEnumeration"/>
+			<xs:element name="Checksum" type="IBIS-IP.byte" minOccurs="4" maxOccurs="32"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/IBIS-IP_Enumerations_V2.4.xsd
+++ b/IBIS-IP_Enumerations_V2.4.xsd
@@ -72,7 +72,7 @@
 			<xs:enumeration value="Bike"/>
 			<xs:enumeration value="Child"/>
 			<xs:enumeration value="Pram"/>
-			<xs:enumeration value="WheelChair"/>
+			<xs:enumeration value="Wheelchair"/>
 			<xs:enumeration value="Unidentified"/>
 			<xs:enumeration value="Other"/>
 		</xs:restriction>

--- a/IBIS-IP_Enumerations_V2.4.xsd
+++ b/IBIS-IP_Enumerations_V2.4.xsd
@@ -1,0 +1,679 @@
+<?xml version="1.0"?>
+<!-- Mit XMLSpy v2012 rel. 2 sp1 (http://www.altova.com) von Dirk Weißer (INIT GmbH) bearbeitet -->
+<!-- Mit XMLSpy v2017 rel. 3  (http://www.altova.com) von Peter Schussler (DResearch) bearbeitet, VideoDienste hinzugefügt -->
+<!-- Mit XMLSpy v2018 rel. 2  (http://www.altova.com) von Bernd Schubert (iris-GmbH) bearbeitet, IBIS-IP 2.1 -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<!--==== Definition of Enumerations-->
+	<xs:simpleType name="ConnectionStateEnumeration">
+		<xs:annotation>
+			<xs:documentation>Information whether a connection will rest protected</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ConnectionBroken"/>
+			<xs:enumeration value="ConnectionOK"/>
+			<xs:enumeration value="NoInformationAvailable"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ConnectionTypeEnumeration">
+		<xs:annotation>
+			<xs:documentation>Value, which is necessary for distinction between an Interchange and a Connection</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Interchange"/>
+			<xs:enumeration value="ProtectedConnection"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DataIntervalEnumeration">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DistanceData"/>
+			<xs:enumeration value="GNSSData"/>
+			<xs:enumeration value="Heartbeat"/>
+			<xs:enumeration value="NetworkLocationData"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DeviceClassEnumeration">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="OnBoardUnit"/>
+			<xs:enumeration value="SideDisplay"/>
+			<xs:enumeration value="FrontDisplay"/>
+			<xs:enumeration value="InteriorDisplay"/>
+			<xs:enumeration value="Validator"/>
+			<xs:enumeration value="TicketVendingMachine"/>
+			<xs:enumeration value="AnnouncementSystem"/>
+			<xs:enumeration value="MMI"/>
+			<xs:enumeration value="VideoSystem"/>
+			<xs:enumeration value="APC"/>
+			<xs:enumeration value="MobileInterface"/>
+			<xs:enumeration value="Other"/>
+			<xs:enumeration value="TestDevice"/>
+			<xs:enumeration value="MultiFunctionalDisplay"/>
+			<xs:enumeration value="CombiDevice"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DeviceStateEnumeration">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="defective"/>
+			<xs:enumeration value="warning"/>
+			<xs:enumeration value="notavailable"/>
+			<xs:enumeration value="running"/>
+			<xs:enumeration value="readyForShutdown"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DeviceTaskEnumeration">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="restart"/>
+			<xs:enumeration value="start_standby"/>
+			<xs:enumeration value="stop_standby"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DoorCountingObjectClassEnumeration">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Adult"/>
+			<xs:enumeration value="Bike"/>
+			<xs:enumeration value="Child"/>
+			<xs:enumeration value="Pram"/>
+			<xs:enumeration value="WheelChair"/>
+			<xs:enumeration value="Unidentified"/>
+			<xs:enumeration value="Other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DoorCountingQualityEnumeration">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Defect"/>
+			<xs:enumeration value="Regular"/>
+			<xs:enumeration value="Sabotage"/>
+			<xs:enumeration value="Other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DoorOpenStateEnumeration">
+		<xs:annotation>
+			<xs:documentation>Information on the state of the doors in a vehicle</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DoorsOpen"/>
+			<xs:enumeration value="AllDoorsClosed"/>
+			<xs:enumeration value="SingleDoorOpen"/>
+			<xs:enumeration value="SingleDoorClosed"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DoorOperationStateEnumeration">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Locked"/>
+			<xs:enumeration value="Normal"/>
+			<xs:enumeration value="EmergencyRelease"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ErrorCodeEnumeration">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DataEstimated"/>
+			<xs:enumeration value="FaultData"/>
+			<xs:enumeration value="NoScheduleDataAvailable"/>
+			<xs:enumeration value="DeviceMissing"/>
+			<xs:enumeration value="NoServiceResponse"/>
+			<xs:enumeration value="ImportantDataNotAvailable"/>
+			<xs:enumeration value="DataNotValid"/>
+			<xs:enumeration value="OperationNotSupported"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExitSideEnumeration">
+		<xs:annotation>
+			<xs:documentation>Information on the ExitSide (sic!)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="both"/>
+			<xs:enumeration value="left"/>
+			<xs:enumeration value="right"/>
+			<xs:enumeration value="unknown"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="GNSSCoordinateSystemEnumeration">
+		<xs:annotation>
+			<xs:documentation>Information on the GNSS-Coordinate-System</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CH1903"/>
+			<xs:enumeration value="ETSR89"/>
+			<xs:enumeration value="IERS"/>
+			<xs:enumeration value="NAD27"/>
+			<xs:enumeration value="NAD83"/>
+			<xs:enumeration value="WGS84"/>
+			<xs:enumeration value="WGS72"/>
+			<xs:enumeration value="SGS85"/>
+			<xs:enumeration value="P90"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="GNSSQualityEnumeration">
+		<xs:annotation>
+			<xs:documentation>Information on the GNSS-Quality</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="dGPS"/>
+			<xs:enumeration value="Estimated"/>
+			<xs:enumeration value="GPS"/>
+			<xs:enumeration value="NotValid"/>
+			<xs:enumeration value="Unknown"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="GNSSTypeEnumeration">
+		<xs:annotation>
+			<xs:documentation>Information on the type of GNSS</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="GPS"/>
+			<xs:enumeration value="Glonass"/>
+			<xs:enumeration value="Galileo"/>
+			<xs:enumeration value="Beidou"/>
+			<xs:enumeration value="IRNSS"/>
+			<xs:enumeration value="other"/>
+			<xs:enumeration value="DeadReckoning"/>
+			<xs:enumeration value="MixedGNSSTypes"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="JourneyModeEnumeration">
+		<xs:annotation>
+			<xs:documentation>Information on the kind of a trip</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="NoTrip"/>
+			<xs:enumeration value="AdditionalTrip"/>
+			<xs:enumeration value="ServiceTrip"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LocationStateEnumeration">
+		<xs:annotation>
+			<xs:documentation>Information on the location in a very general way</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AfterStop"/>
+			<xs:enumeration value="AtStop"/>
+			<xs:enumeration value="BeforeStop"/>
+			<xs:enumeration value="BetweenStop"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MessageTypeEnumeration">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Status"/>
+			<xs:enumeration value="Warning"/>
+			<xs:enumeration value="Error"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RouteDeviationEnumeration">
+		<xs:annotation>
+			<xs:documentation>Information whether the vehicle is onroute or offroute</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="onroute"/>
+			<xs:enumeration value="offroute"/>
+			<xs:enumeration value="unknown"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RouteDirectionEnumeration">
+		<xs:annotation>
+			<xs:documentation>Information on the general direction of a route</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Forward"/>
+			<xs:enumeration value="Backward"/>
+			<xs:enumeration value="Clockwise"/>
+			<xs:enumeration value="Counterclockwise"/>
+			<xs:enumeration value="Other"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ServiceNameEnumeration">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AnalogRadioService"/>
+			<xs:enumeration value="CustomerInformationService"/>
+			<xs:enumeration value="DeviceManagementService"/>
+			<xs:enumeration value="JourneyInformationService"/>
+			<xs:enumeration value="BeaconLocationService"/>
+			<xs:enumeration value="DistanceLocationService"/>
+			<xs:enumeration value="DoorStateService"/>
+			<xs:enumeration value="GNSSLocationService"/>
+			<xs:enumeration value="HTMLDisplayService"/>
+			<xs:enumeration value="NetworkLocationService"/>
+			<xs:enumeration value="PassengerCountingService"/>
+			<xs:enumeration value="SystemMonitoringService"/>
+			<xs:enumeration value="TestService"/>
+			<xs:enumeration value="TicketValidationService"/>
+			<xs:enumeration value="TicketingService"/>
+			<xs:enumeration value="TimeService"/>
+			<xs:enumeration value="TrainSetDataService"/>
+			<xs:enumeration value="TrainSetInformationService"/>
+			<xs:enumeration value="TrainSetManagementService"/>
+			<xs:enumeration value="VideoLiveService"/>
+			<xs:enumeration value="VideoRecordingService"/>
+			<xs:enumeration value="VideoDisplayService"/>			
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ServiceStateEnumeration">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="defective"/>
+			<xs:enumeration value="notrunning"/>
+			<xs:enumeration value="running"/>
+			<xs:enumeration value="standby"/>
+			<xs:enumeration value="starting"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SystemDocumentationInformationEnumeration">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ErrorMessage"/>
+			<xs:enumeration value="StatusMessage"/>
+			<xs:enumeration value="WarningMessage"/>
+			<xs:enumeration value="All"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TicketRazziaInformationEnumeration">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="razzia"/>
+			<xs:pattern value="norazzia"/>
+			<xs:enumeration value="razzia"/>
+			<xs:enumeration value="norazzia"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TicketValidationEnumeration">
+		<xs:annotation>
+			<xs:documentation>Information about the result of ticket validation</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="valid"/>
+			<xs:enumeration value="notvalid"/>
+			<xs:enumeration value="NoCard"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="VehicleModeEnumeration">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="air"/>
+			<xs:enumeration value="bus"/>
+			<xs:enumeration value="coach"/>
+			<xs:enumeration value="ferry"/>
+			<xs:enumeration value="metro"/>
+			<xs:enumeration value="rail"/>
+			<xs:enumeration value="tram"/>
+			<xs:enumeration value="underground"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TripStateEnumeration">
+		<xs:annotation>
+			<xs:documentation>Information about trip state,
+			EmptyRun: trips is selected but has not yet started ( e.g. drive from depot to first stop point )
+			OnTrip: on trip ,
+			OffTrip: trip has ended there is no next trip yet, ( e.g. drive to the depot )
+			TripBreak: trip has already started but there is a break now it will be continued ( e.g. driver break),
+			OffDuty: no trip, bus parked ( e.g. driver has logged of, OBU still running )
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="EmptyRun"/>
+			<xs:enumeration value="OnTrip"/>
+			<xs:enumeration value="OffTrip"/>
+			<xs:enumeration value="TripBreak"/>
+			<xs:enumeration value="OffDuty"/>
+			<xs:enumeration value="unknown"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PtSubModesEnumeration">
+		<xs:annotation>
+			<xs:documentation>compliant with NETEX</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:NMTOKEN">
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="undefined"/>
+			<xs:enumeration value="AirSubmode"/>
+			<xs:enumeration value="BusSubmode"/>
+			<xs:enumeration value="CoachSubmode"/>
+			<xs:enumeration value="FunicularSubmode"/>
+			<xs:enumeration value="MetroSubmode"/>
+			<xs:enumeration value="TramSubmode"/>
+			<xs:enumeration value="TelecabinSubmode"/>
+			<xs:enumeration value="RailSubmode"/>
+			<xs:enumeration value="WaterSubmode"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PrivateSubModesEnumeration">
+		<xs:annotation>
+			<xs:documentation>compliant with NETEX</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:NMTOKEN">
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="undefined"/>
+			<xs:enumeration value="SelfDriveSubmode"/>
+			<xs:enumeration value="TaxiSubmode"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:group name="PtSubmodeChoiceGroup">
+		<xs:annotation>
+			<xs:documentation>PT Transport Sub Modes.</xs:documentation>
+		</xs:annotation>
+		<xs:choice>
+			<xs:element ref="AirSubmode"/>
+			<xs:element ref="BusSubmode"/>
+			<xs:element ref="CoachSubmode"/>
+			<xs:element ref="FunicularSubmode"/>
+			<xs:element ref="MetroSubmode"/>
+			<xs:element ref="TramSubmode"/>
+			<xs:element ref="TelecabinSubmode"/>
+			<xs:element ref="RailSubmode"/>
+			<xs:element ref="WaterSubmode"/>
+		</xs:choice>
+	</xs:group>
+	<xs:group name="PrivateSubmodeChoiceGroup">
+		<xs:annotation>
+			<xs:documentation>Non PT Road Submodes.</xs:documentation>
+		</xs:annotation>
+		<xs:choice>
+			<xs:element ref="TaxiSubmode"/>
+			<xs:element ref="SelfDriveSubmode"/>
+		</xs:choice>
+	</xs:group>
+	<!-- ======================================================================= -->
+	<xs:element name="RailSubmode" type="RailSubmodeEnumeration" default="unknown">
+		<xs:annotation>
+			<xs:documentation>TPEG pti02 Rail submodes loc13.
+			See also See ERA B.4.7009 - Name: Item description code.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:simpleType name="RailSubmodeEnumeration">
+		<xs:annotation>
+			<xs:documentation>Values for Rail MODEs of TRANSPORT: TPEG pti_table_02, train link loc_table_13.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:NMTOKEN">
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="local"/>
+			<xs:enumeration value="highSpeedRail">
+				<xs:annotation>
+					<xs:documentation>See ERA B.4.7009 - Name: Item description code: (8 high speed train). Long distance train formed by a unit capable for high speed running on high speed or normal lines most modern train unit</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="suburbanRailway">
+				<xs:annotation>
+					<xs:documentation>See ERA B.4.7009 - Name: Item description code: . (12 suburban) Regional train organised by the regional government public transport in and around cities, running on its own freeways underground or overground, operational running with signals</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="regionalRail">
+				<xs:annotation>
+					<xs:documentation>See ERA B.4.7009 - Name: Item description code. (11 Regional) Regional train organised by the regional government even if formed by a unit capable for high speed running on high speed lines</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="interregionalRail">
+				<xs:annotation>
+					<xs:documentation>See ERA B.4.7009 - Name: Item description code: (10 Interregional) Regional train running in more than one region.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="longDistance">
+				<xs:annotation>
+					<xs:documentation>See ERA B.4.7009 - Name: Item description code: (9 Intercity). Long distance train formed by a unit capable for high speed or not running on high speed or normal lines modern train unit high quality service restricted stopping pattern</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="international"/>
+			<xs:enumeration value="sleeperRailService"/>
+			<xs:enumeration value="nightRail"/>
+			<xs:enumeration value="carTransportRailService">
+				<xs:annotation>
+					<xs:documentation>See ERA B.4.7009 - Name: Item description code: (14 Motor rail) Service transporting passenger's motor vehicle passengers are admitted either with vehicle only or with or without vehicle Service mode</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="touristRailway">
+				<xs:annotation>
+					<xs:documentation>See ERA B.4.7009 - Name: Item description code: (16 Historic train).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="airportLinkRail"/>
+			<xs:enumeration value="railShuttle"/>
+			<xs:enumeration value="replacementRailService"/>
+			<xs:enumeration value="specialTrain"/>
+			<xs:enumeration value="crossCountryRail"/>
+			<xs:enumeration value="rackAndPinionRailway">
+				<xs:annotation>
+					<xs:documentation>See ERA B.4.7009 - Name: Item description code: (15 Mountain train) Local train adapted for running in mountain railway lines.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- ======================================================================= -->
+	<xs:element name="CoachSubmode" type="CoachSubmodeEnumeration" default="unknown">
+		<xs:annotation>
+			<xs:documentation>TPEG pti03 Coach submodes.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:simpleType name="CoachSubmodeEnumeration">
+		<xs:annotation>
+			<xs:documentation>Values for Coach MODEs of TRANSPORT: TPEG pti_table_03.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:NMTOKEN">
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="undefined"/>
+			<xs:enumeration value="internationalCoach"/>
+			<xs:enumeration value="nationalCoach"/>
+			<xs:enumeration value="shuttleCoach"/>
+			<xs:enumeration value="regionalCoach"/>
+			<xs:enumeration value="specialCoach"/>
+			<xs:enumeration value="schoolCoach"/>
+			<xs:enumeration value="sightseeingCoach"/>
+			<xs:enumeration value="touristCoach"/>
+			<xs:enumeration value="commuterCoach"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- ======================================================================= -->
+	<xs:element name="MetroSubmode" type="MetroSubmodeEnumeration" default="unknown">
+		<xs:annotation>
+			<xs:documentation>TPEG pti04 Metro submodes.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:simpleType name="MetroSubmodeEnumeration">
+		<xs:annotation>
+			<xs:documentation>Values for Metro MODEs of TRANSPORT: TPEG pti_table_04.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:NMTOKEN">
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="undefined"/>
+			<xs:enumeration value="metro"/>
+			<xs:enumeration value="tube"/>
+			<xs:enumeration value="urbanRailway"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- ======================================================================= -->
+	<xs:element name="BusSubmode" type="BusSubmodeEnumeration" default="unknown">
+		<xs:annotation>
+			<xs:documentation>TPEG pti05 Bus submodes.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:simpleType name="BusSubmodeEnumeration">
+		<xs:annotation>
+			<xs:documentation>Values for Bus MODEs of TRANSPORT: TPEG pti_table_05, col_table_10.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:NMTOKEN">
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="undefined"/>
+			<xs:enumeration value="localBus"/>
+			<xs:enumeration value="regionalBus"/>
+			<xs:enumeration value="expressBus"/>
+			<xs:enumeration value="nightBus"/>
+			<xs:enumeration value="postBus"/>
+			<xs:enumeration value="specialNeedsBus"/>
+			<xs:enumeration value="mobilityBus"/>
+			<xs:enumeration value="mobilityBusForRegisteredDisabled"/>
+			<xs:enumeration value="sightseeingBus"/>
+			<xs:enumeration value="shuttleBus"/>
+			<xs:enumeration value="highFrequencyBus"/>
+			<xs:enumeration value="dedicatedLaneBus"/>
+			<xs:enumeration value="schoolBus"/>
+			<xs:enumeration value="schoolAndPublicServiceBus"/>
+			<xs:enumeration value="railReplacementBus"/>
+			<xs:enumeration value="demandAndResponseBus"/>
+			<xs:enumeration value="airportLinkBus"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- ======================================================================= -->
+	<xs:element name="TramSubmode" type="TramSubmodeEnumeration" default="unknown">
+		<xs:annotation>
+			<xs:documentation>TPEG pti06 Tram submodes.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:simpleType name="TramSubmodeEnumeration">
+		<xs:annotation>
+			<xs:documentation>Values for Tram MODEs of TRANSPORT: TPEG pti_table_06, col_table_12.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:NMTOKEN">
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="undefined"/>
+			<xs:enumeration value="cityTram"/>
+			<xs:enumeration value="localTram"/>
+			<xs:enumeration value="regionalTram"/>
+			<xs:enumeration value="sightseeingTram"/>
+			<xs:enumeration value="shuttleTram"/>
+			<xs:enumeration value="trainTram"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- ======================================================================= -->
+	<xs:element name="WaterSubmode" type="WaterSubmodeEnumeration" default="unknown">
+		<xs:annotation>
+			<xs:documentation>TPEG pti07 Water submodes.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:simpleType name="WaterSubmodeEnumeration">
+		<xs:annotation>
+			<xs:documentation>Values for Water MODEs of TRANSPORT: TPEG pti_table_07.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:NMTOKEN">
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="undefined"/>
+			<xs:enumeration value="internationalCarFerry"/>
+			<xs:enumeration value="nationalCarFerry"/>
+			<xs:enumeration value="regionalCarFerry"/>
+			<xs:enumeration value="localCarFerry"/>
+			<xs:enumeration value="internationalPassengerFerry"/>
+			<xs:enumeration value="nationalPassengerFerry"/>
+			<xs:enumeration value="regionalPassengerFerry"/>
+			<xs:enumeration value="localPassengerFerry"/>
+			<xs:enumeration value="postBoat"/>
+			<xs:enumeration value="trainFerry"/>
+			<xs:enumeration value="roadFerryLink"/>
+			<xs:enumeration value="airportBoatLink"/>
+			<xs:enumeration value="highSpeedVehicleService"/>
+			<xs:enumeration value="highSpeedPassengerService"/>
+			<xs:enumeration value="sightseeingService"/>
+			<xs:enumeration value="schoolBoat"/>
+			<xs:enumeration value="cableFerry"/>
+			<xs:enumeration value="riverBus"/>
+			<xs:enumeration value="scheduledFerry"/>
+			<xs:enumeration value="shuttleFerryService"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- ======================================================================= -->
+	<xs:element name="AirSubmode" type="AirSubmodeEnumeration" default="unknown">
+		<xs:annotation>
+			<xs:documentation>TPEG pti08 Air submodes.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:simpleType name="AirSubmodeEnumeration">
+		<xs:annotation>
+			<xs:documentation>Values for Air MODEs of TRANSPORT: TPEG pti_table_08.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:NMTOKEN">
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="undefined"/>
+			<xs:enumeration value="internationalFlight"/>
+			<xs:enumeration value="domesticFlight"/>
+			<xs:enumeration value="intercontinentalFlight"/>
+			<xs:enumeration value="domesticScheduledFlight"/>
+			<xs:enumeration value="shuttleFlight"/>
+			<xs:enumeration value="intercontinentalCharterFlight"/>
+			<xs:enumeration value="internationalCharterFlight"/>
+			<xs:enumeration value="roundTripCharterFlight"/>
+			<xs:enumeration value="sightseeingFlight"/>
+			<xs:enumeration value="helicopterService"/>
+			<xs:enumeration value="domesticCharterFlight"/>
+			<xs:enumeration value="SchengenAreaFlight"/>
+			<xs:enumeration value="airshipService"/>
+			<xs:enumeration value="shortHaulInternationalFlight"/>
+			<xs:enumeration value="canalBarge">
+				<xs:annotation>
+					<xs:documentation source="Not in TPEG"/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- ======================================================================= -->
+	<xs:element name="TelecabinSubmode" type="TelecabinSubmodeEnumeration" default="unknown">
+		<xs:annotation>
+			<xs:documentation>TPEG pti09 Telecabin submodes.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:simpleType name="TelecabinSubmodeEnumeration">
+		<xs:annotation>
+			<xs:documentation>Values for Telecabin MODEs of TRANSPORT: TPEG pti_table_09, col_table_14.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:NMTOKEN">
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="undefined"/>
+			<xs:enumeration value="telecabin"/>
+			<xs:enumeration value="cableCar"/>
+			<xs:enumeration value="lift"/>
+			<xs:enumeration value="chairLift"/>
+			<xs:enumeration value="dragLift"/>
+			<xs:enumeration value="telecabinLink"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- ======================================================================= -->
+	<xs:element name="FunicularSubmode" type="FunicularSubmodeEnumeration" default="unknown">
+		<xs:annotation>
+			<xs:documentation>TPEG pti10 Funicular submodes.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:simpleType name="FunicularSubmodeEnumeration">
+		<xs:annotation>
+			<xs:documentation>Values for Funicular MODEs of TRANSPORT: TPEG pti_table_10.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:NMTOKEN">
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="funicular"/>
+			<xs:enumeration value="streetCableCar"/>
+			<xs:enumeration value="allFunicularServices"/>
+			<xs:enumeration value="undefinedFunicular"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- ======================================================================= -->
+	<xs:element name="TaxiSubmode" type="TaxiSubmodeEnumeration" default="unknown">
+		<xs:annotation>
+			<xs:documentation>TPEG pti11 Taxi submodes.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:simpleType name="TaxiSubmodeEnumeration">
+		<xs:annotation>
+			<xs:documentation>Values for Taxi MODEs of TRANSPORT: TPEG pti_table_11.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:NMTOKEN">
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="undefined"/>
+			<xs:enumeration value="communalTaxi"/>
+			<xs:enumeration value="charterTaxi"/>
+			<xs:enumeration value="waterTaxi"/>
+			<xs:enumeration value="railTaxi"/>
+			<xs:enumeration value="bikeTaxi"/>
+			<xs:enumeration value="blackCab"/>
+			<xs:enumeration value="miniCab"/>
+			<xs:enumeration value="allTaxiServices"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- ======================================================================= -->
+	<xs:element name="SelfDriveSubmode" type="SelfDriveSubmodeEnumeration" default="unknown">
+		<xs:annotation>
+			<xs:documentation>TPEG pti12 SelfDrive submodes.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:simpleType name="SelfDriveSubmodeEnumeration">
+		<xs:annotation>
+			<xs:documentation>Values for SelfDrive MODEs of TRANSPORT: TPEG pti_table_12.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:NMTOKEN">
+			<xs:enumeration value="unknown"/>
+			<xs:enumeration value="undefined"/>
+			<xs:enumeration value="hireCar"/>
+			<xs:enumeration value="hireVan"/>
+			<xs:enumeration value="hireMotorbike"/>
+			<xs:enumeration value="hireCycle"/>
+			<xs:enumeration value="allHireVehicles"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!-- ======================================================================= -->
+</xs:schema>

--- a/IBIS-IP_TicketValidationService_V2.4.xsd
+++ b/IBIS-IP_TicketValidationService_V2.4.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="IBIS-IP_common_V2.4.xsd"/>
-	<xs:include schemaLocation="IBIS-IP_Enumerations_V2.2.xsd"/>
+	<xs:include schemaLocation="IBIS-IP_Enumerations_V2.4.xsd"/>
 	
 	<!--====  TicketValidationService ====-->
 	<xs:element name="TicketValidationService.GetCurrentTariffStopResponse"  type="TicketValidationService.GetCurrentTariffStopResponseStructure"/>

--- a/IBIS-IP_VideoRecordingService_V2.4.xsd
+++ b/IBIS-IP_VideoRecordingService_V2.4.xsd
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<!-- DResearch VideoServices v2.0 naming according to VDV 301 v2.0, Dipl.-Ing (FH) Peter Schüßler, MBA (DResearch Fahrzeugelektronik GmbH), 2018-01-12 -->
+<!-- Include this XSD Scheme to use the IBIS-IP VideoRecordingService (request of information of all available video sources in the IBIS-IP system) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="IBIS-IP_common_V2.0.xsd"/>
+	<xs:include schemaLocation="IBIS-IP_Enumerations_V2.0.xsd"/>
+	<!--==== VideoRecording Enumerations- Operations ====-->
+	<xs:simpleType name="VideoRecordingStateEnumeration">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="RRM"/>
+			<xs:enumeration value="ERM"/>
+			<xs:enumeration value="RRMFUT"/>
+			<xs:enumeration value="ERMFUT"/>
+			<xs:enumeration value="OFF"/>
+			<xs:enumeration value="PAUSE"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RecordingSystemStartStopModeEnumeration">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="IBIS-IP"/>
+			<xs:enumeration value="CVCU"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<!--==== VideoRecordingService - Operations ====-->
+	<xs:group name="VideoRecordingServiceGroup">
+		<xs:sequence>
+			<xs:element name="VideoRecordingService.StartRecordingRRMResponse" type="VideoRecordingService.VideoRecordingStateResponseStructure"/>
+			<xs:element name="VideoRecordingService.StartRecordingERMResponse" type="VideoRecordingService.VideoRecordingStateResponseStructure"/>
+			<xs:element name="VideoRecordingService.PauseRecordingRRMRequest" type="VideoRecordingService.PauseRecordingRRMRequestStruture"/>
+			<xs:element name="VideoRecordingService.PauseRecordingRRMResponse" type="VideoRecordingService.VideoRecordingStateResponseStructure"/>
+			<xs:element name="VideoRecordingService.StopRecordingResponse" type="VideoRecordingService.VideoRecordingStateResponseStructure"/>
+			<xs:element name="VideoRecordingService.ForceStopRecordingResponse" type="VideoRecordingService.VideoRecordingStateResponseStructure"/>
+			<xs:element name="VideoRecordingService.GetVideoRecordingStateResponse" type="VideoRecordingService.VideoRecordingStateResponseStructure"/>
+		</xs:sequence>
+	</xs:group>
+	<!--=== ServiceDefinitions ===-->
+	<!--++ StartRecordingRRM ++-->
+	<xs:element name="VideoRecordingService.StartRecordingRRMResponse" type="VideoRecordingService.VideoRecordingStateResponseStructure"/>
+	<xs:complexType name="VideoRecordingService.VideoRecordingStateResponseStructure">
+		<xs:choice>
+			<xs:element name="VideoRecordingState" type="VideoRecordingStateStructure"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<!--++ StartRecordingERM ++-->
+	<xs:element name="VideoRecordingService.StartRecordingERMResponse" type="VideoRecordingService.VideoRecordingStateResponseStructure"/>
+	<!--++ PauseRecordingRRM ++-->
+	<xs:element name="VideoRecordingService.PauseRecordingRRMRequest" type="VideoRecordingService.PauseRecordingRRMRequestStruture"/>
+	<xs:complexType name="VideoRecordingService.PauseRecordingRRMRequestStruture">
+		<xs:choice>
+			<xs:element name="PauseInterval" type="IBIS-IP.int"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:element name="VideoRecordingService.PauseRecordingRRMResponse" type="VideoRecordingService.VideoRecordingStateResponseStructure"/>
+	<!--++ StopRecording ++-->
+	<xs:element name="VideoRecordingService.StopRecordingResponse" type="VideoRecordingService.VideoRecordingStateResponseStructure"/>
+	<!--++ ForceStopRecording ++-->
+	<xs:element name="VideoRecordingService.ForceStopRecordingResponse" type="VideoRecordingService.VideoRecordingStateResponseStructure"/>
+	<!--++ GetVideoRecordingState ++-->
+	<xs:element name="VideoRecordingService.GetVideoRecordingStateResponse" type="VideoRecordingService.VideoRecordingStateResponseStructure"/>
+	<xs:complexType name="VideoRecordingStateStructure">
+		<xs:sequence>
+			<xs:element name="State" type="VideoRecordingStateEnumeration"/>
+			<xs:element name="AlarmArchiveFillLevel" type="IBIS-IP.int" minOccurs="0"/>
+			<xs:element name="StartStopMode" type="RecordingSystemStartStopModeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/IBIS-IP_common_V2.4.xsd
+++ b/IBIS-IP_common_V2.4.xsd
@@ -447,6 +447,21 @@
 					<xs:documentation>identifier of a symbol number , which is used by displays see LINIEN_CODE in VDV 452 chapter 9.7.2 REC_LID</xs:documentation>
 				</xs:annotation>
 			</xs:element>
+			<xs:element name="LinePublicCode" type="IBIS-IP.string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Published line identification for the passenger. For displaying the line on all media such as line network maps, timetable printouts, passenger information on the internet, on signs, the stop displays, on the exterior and interior displays of the vehicles.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="LineSymbolText" type="IBIS-IP.string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Specification of a xml formatted text to reference an symbol for special lines. Used as alternative to the LineSymbolCode. For example for displaying an airport symbol the following string could be used: <icon type=" airport "> airport </icon></xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ExternalLineRef" type="IBIS-IP.string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>International line ID e.g. in Germany according to VDV433 DLID, internationally according to NeTEx.</xs:documentation>
+				</xs:annotation>
+			</xs:element>		
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="LogMessageStructure">
@@ -597,7 +612,9 @@
 			<xs:element name="DisplayContent" type="DisplayContentStructure" maxOccurs="unbounded"/>
 			<xs:element name="StopAnnouncement" type="AnnouncementStructure" minOccurs="0" maxOccurs="unbounded"/>
 			<xs:element name="ArrivalScheduled" type="IBIS-IP.dateTime" minOccurs="0"/>
+			<xs:element name="ArrivalExpected" type="IBIS-IP.dateTime" minOccurs="0"/>
 			<xs:element name="DepartureScheduled" type="IBIS-IP.dateTime" minOccurs="0"/>
+			<xs:element name="DepartureExpected" type="IBIS-IP.dateTime" minOccurs="0"/>
 			<xs:element name="RecordedArrivalTime" type="IBIS-IP.dateTime" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>This Value is needed for the demonstration at the SSB</xs:documentation>
@@ -657,6 +674,31 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="FareZone" type="IBIS-IP.NMTOKEN" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="StopShortName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Short name of the stop in the planning program and ITCS. To identify a stop on media with limited display length, e.g. older interior displays, on-board computer or ticket printer terminal.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="StopLongNo" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Stop number that is used throughout the transport association (PTA) for activation of ticket printers and ticket validators. This number is not necessarily unique and is only used for stops that are used productively. This number is not required for non-productive stops (e.g. depots, parking facilities, car parks).</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PointNumber" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Transport company-wide internal unique number of a stopping point in the network.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="StopGlobalID" type="IBIS-IP.string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>International stop ID e.g. in Germany according to VDV432 (DHID), internationally according to NeTEx, NAPTAN.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="StopPointGlobalID" type="IBIS-IP.string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>International stopping point ID e.g. in Germany according to VDV432 (DHID), internationally according to NeTEx, NAPTAN.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="StopPointTariffInformationStructure">

--- a/IBIS-IP_common_V2.4.xsd
+++ b/IBIS-IP_common_V2.4.xsd
@@ -774,7 +774,17 @@
 				<xs:annotation>
 					<xs:documentation>The path destination number (RoutenZiel-Nummer) the trip is operated </xs:documentation>
 				</xs:annotation>
-			</xs:element>									
+			</xs:element>
+			<xs:element name="BlockNumber" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Unique block number per day of operational day. Used for logon on the vehicle in block operation.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ExternalVehicleJourneyRef" type="IBIS-IP.string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>International trip ID e.g. in Germany according to VDV433 (DFID), internationally according to NeTEx.</xs:documentation>
+				</xs:annotation>
+			</xs:element>			
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="TripSequenceStructure">

--- a/IBIS-IP_common_V2.4.xsd
+++ b/IBIS-IP_common_V2.4.xsd
@@ -448,7 +448,7 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="LinePublicCode" type="IBIS-IP.string" minOccurs="0" maxOccurs="1"/>			
-			<xs:element name="LineSymbolText" type="IBIS-IP.string" minOccurs="0" maxOccurs="1"/>			
+			<xs:element name="LineSymbolText" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>			
 			<xs:element name="ExternalLineRef" type="IBIS-IP.string" minOccurs="0" maxOccurs="1"/>			
 		</xs:sequence>
 	</xs:complexType>

--- a/IBIS-IP_common_V2.4.xsd
+++ b/IBIS-IP_common_V2.4.xsd
@@ -1,0 +1,1051 @@
+<?xml version="1.0"?>
+<!-- Mit XMLSpy v2012 rel. 2 sp1 (http://www.altova.com) von Dirk Weißer (INIT GmbH) bearbeitet -->
+<!-- Mit XMLSpy v2018 rel. 2  (http://www.altova.com) von Bernd Schubert (iris-GmbH) bearbeitet, IBIS-IP 2.1 -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="IBIS-IP_Enumerations_V2.4.xsd"/>
+	<!--==== DataDefinitions ====-->
+	<xs:complexType name="AdditionalAnnouncementStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for decscribing the informations for an additional announcement</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="AnnouncementRef" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>Reference to the Announcement in the schedule data</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AnnouncementText" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Text of the Announcement</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AnnouncementTTSText" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Text of the Announcement for a text-to-speech-system</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice minOccurs="0">
+				<xs:element name="ImmediateInformation" type="IBIS-IP.boolean">
+					<xs:annotation>
+						<xs:documentation>true, if the additional annoucement should be pronounced immiditaley</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="PeriodicalInformation" type="IBIS-IP.duration">
+					<xs:annotation>
+						<xs:documentation>period in which the addional announcement should be played </xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="SpecificPoint" type="SpecificPointStructure">
+					<xs:annotation>
+						<xs:documentation>describes a specific point, where the addional announcement should be played</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AnnouncementStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for decscribing the informations for an regular announcement</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="AnnouncementRef" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>Reference to the Announcement in the schedule data</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AnnouncementText" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Text of the Announcement</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AnnouncementTTSText" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Text of the Announcement for a text-to-speech-system</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BayAreaStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for describing an area at the stop point for detecting the right stop position</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="BeforeBay" type="IBIS-IP.double" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Distance before the defined Stoppoint, where the detection area begins, value in [m]</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BehindBay" type="IBIS-IP.double" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Distance behind the defined Stoppoint, where the detection area begins, value in [m]</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BeaconPointStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for describing a beacon point</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="PointRef" type="IBIS-IP.NMTOKEN" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Reference to the beacon point in the schedule data</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BeaconCode" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>Code of the beacon point</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ShortName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Shortname of the beaon point</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Description" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Text, which gives some additional information on the beacon point</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CardApplInformations">
+		<xs:sequence>
+			<xs:element name="CardApplInformationLength" type="IBIS-IP.unsignedInt">
+				<xs:annotation>
+					<xs:documentation>Length of the bytearray of applikationdata</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CardApplInformationData" type="IBIS-IP.byte" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Applikationdata from Card as Byte-Array </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CardTicketData">
+		<xs:sequence>
+			<xs:element name="CardTicketDataID" type="IBIS-IP.unsignedLong"/>
+			<xs:element name="CardTicketDataLength" type="IBIS-IP.unsignedInt">
+				<xs:annotation>
+					<xs:documentation>Length of the bytearray of ticketdata</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CardTicketData" type="IBIS-IP.byte" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Ticketdata from Card as  Byte-Array</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CardType">
+		<xs:sequence>
+			<xs:element name="CardSerialNumber" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="CardTypeID" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="CardTypeText" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ConnectionStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for describing a connection</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="StopRef" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>StopPoint, where the connection should take place (from planning system)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ConnectionRef" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>StopPoint-referenced connection-reference</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ConnectionType" type="ConnectionTypeEnumeration">
+				<xs:annotation>
+					<xs:documentation>Describes the kind of connection </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DisplayContent" type="DisplayContentStructure" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Structure for desccribing the information which is shown on a head- or sidesign</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Platform" type="IBIS-IP.string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Platform, on which the connection should take place</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ConnectionState" type="ConnectionStateEnumeration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Describes the status of the connection</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="TransportMode" type="VehicleStructure" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Describes the mode of the pick-up vehicle, DEPRECATED !, THE ConnectionMode SHOULD BE USED INSTEAD</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ConnectionMode" type="NetexMode" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Mode- and Submode information of the pick-up vehicle in accordance with Netex</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ExpectedDepartureTime" type="IBIS-IP.dateTime" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Information, at which time the leaving vehicle will depart based on realtime information</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ScheduledDepartureTime" type="IBIS-IP.dateTime" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Information, at which time the leaving vehicle is planned to depart</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DataVersionStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for describing data-versions</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="DataType" type="IBIS-IP.string">
+				<xs:annotation>
+					<xs:documentation>Kind of data</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="VersionRef" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>Versionreference of the data</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DataVersionListStructure">
+		<xs:sequence>
+			<xs:element name="DataVersion" type="DataVersionStructure" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DestinationStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for describing destination information</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="DestinationRef" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>Reference to the destination-information in the schedule-data</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DestinationName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Text of the destination</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DestinationShortName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Shorttext of the destination if there is limited space</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DeviceInformationStructure">
+		<xs:sequence>
+			<xs:group ref="DeviceInformationGroup"/>
+			<xs:element name="DataVersionList" type="DataVersionListStructure" minOccurs="0"/>
+			<xs:element name="WebInterfaceAddress" type="IBIS-IP.anyURI" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DeviceSpecificationListStructure">
+		<xs:sequence>
+			<xs:element name="DeviceSpecification" type="DeviceSpecificationStructure" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DeviceSpecificationStructure">
+		<xs:sequence>
+			<xs:element name="DeviceClass" type="DeviceClassEnumeration"/>
+			<xs:element name="DeviceID" type="IBIS-IP.NMTOKEN"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DeviceSpecificationWithStateStructure">
+		<xs:sequence>
+			<xs:element name="DeviceSpecification" type="DeviceSpecificationStructure"/>
+			<xs:element name="DeviceState" type="DeviceStateEnumeration"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DeviceSpecificationWithStateListStructure">
+		<xs:sequence>
+			<xs:element name="DeviceSpecificationWithState" type="DeviceSpecificationWithStateStructure" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DisplayContentStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for describing the information for a headsign or a sidesign</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="DisplayContentRef" type="IBIS-IP.NMTOKEN" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Reference to the display content information in the schedule data</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="LineInformation" type="LineInformationStructure">
+				<xs:annotation>
+					<xs:documentation>Information on the line, which should be displayed</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Destination" type="DestinationStructure">
+				<xs:annotation>
+					<xs:documentation>Information on the destination, which should be displayed</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ViaPoint" type="ViaPointStructure" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Information on the via points which should be displayed</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which could be displayed, e.g. "Extra Ride", "Express", ... </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation1" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which is assigned project-specific</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation2" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which is assigned project-specific</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation3" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which is assigned project-specific</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation4" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which is assigned project-specific</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation5" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which is assigned project-specific</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation6" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which is assigned project-specific</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation7" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which is assigned project-specific</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation8" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which is assigned project-specific</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation9" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which is assigned project-specific</xs:documentation>
+				</xs:annotation>
+			</xs:element>		
+			<xs:element name="RunNumber" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The run number (Kurs-Nummer) the trip is operated </xs:documentation>
+				</xs:annotation>
+			</xs:element>								
+			<xs:group ref="DisplayPolicyGroup" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Group for Display-Information if there is more than one content at the same time</xs:documentation>
+				</xs:annotation>
+			</xs:group>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FareZoneInformationStructure">
+		<xs:sequence>
+			<xs:element name="FareZoneID" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>unique ID for the farezone</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="FareZoneType" type="ZoneType" minOccurs="0"/>
+			<xs:element name="FareZoneLongName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="FareZoneShortName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GlobalCardStatus">
+		<xs:sequence>
+			<xs:element name="GlobalCardStausID" type="IBIS-IP.unsignedInt">
+				<xs:annotation>
+					<xs:documentation>code according EN 1545</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="GlobalCardStatusText" type="IBIS-IP.string" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>text according EN 1545</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GNSSPointStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for describing a GNSS-Point</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="PointRef" type="IBIS-IP.NMTOKEN" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Reference to the point in schedule data</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Longitude" type="GNSSCoordinateStructure"/>
+			<xs:element name="Latitude" type="GNSSCoordinateStructure"/>
+			<xs:element name="Altitude" type="IBIS-IP.double" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GNSSCoordinateStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for describing a GNSS-Point</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Degree" type="IBIS-IP.double"/>
+			<xs:element name="Direction" type="IBIS-IP.string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="JourneyStopInformationStructure">
+		<xs:sequence>
+			<xs:element name="StopRef" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>Reference to the stoppoint from the planning system	</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="StopName" type="InternationalTextType" maxOccurs="unbounded"/>
+			<xs:element name="StopAlternativeName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Platform" type="IBIS-IP.string" minOccurs="0"/>
+			<xs:element name="DisplayContent" type="DisplayContentStructure" maxOccurs="unbounded"/>
+			<xs:element name="Announcement" type="AnnouncementStructure" minOccurs="0"/>
+			<xs:element name="ArrivalScheduled" type="IBIS-IP.dateTime" minOccurs="0"/>
+			<xs:element name="DepartureScheduled" type="IBIS-IP.dateTime" minOccurs="0"/>
+			<xs:element name="Connection" type="ConnectionStructure" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Information on Connections or Interchanges; not in StopSequence because of RealTimeInformation</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BayArea" type="BayAreaStructure" minOccurs="0"/>
+			<xs:element name="GNSSPoint" type="GNSSPointStructure" minOccurs="0"/>
+			<xs:element name="FareZone" type="IBIS-IP.NMTOKEN" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LineInformationStructure">
+		<xs:sequence>
+			<xs:element name="LineRef" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="LineName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="LineShortName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="LineNumber" type="IBIS-IP.int" minOccurs="0"/>
+			<xs:element name="LineCode" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>identifier of a symbol number , which is used by displays see LINIEN_CODE in VDV 452 chapter 9.7.2 REC_LID</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LogMessageStructure">
+		<xs:sequence>
+			<xs:element name="MessageProvider" type="DeviceSpecificationStructure">
+				<xs:annotation>
+					<xs:documentation>Name of the Service or Device, which sends the message, which has to be logged</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Message" type="MessageStructure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MessageStructure">
+		<xs:sequence>
+			<xs:element name="Message-ID" type="IBIS-IP.int"/>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime">
+				<xs:annotation>
+					<xs:documentation>... of the ErrorMessage</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="MessageType" type="MessageTypeEnumeration"/>
+			<xs:element name="MessageText" type="IBIS-IP.string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PointSequenceStructure">
+		<xs:sequence>
+			<xs:element name="Point" type="PointStructure" minOccurs="2" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PointStructure">
+		<xs:sequence>
+			<xs:element name="PointIndex" type="IBIS-IP.int"/>
+			<xs:element name="PointType" type="PointTypeStructure"/>
+			<xs:element name="DistanceToPreviousPoint" type="IBIS-IP.int">
+				<xs:annotation>
+					<xs:documentation>aus REC-SEL bzw. REC_SEL_ZP der VDV 452</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PointTypeStructure">
+		<xs:choice>
+			<xs:element name="StopPoint" type="JourneyStopInformationStructure">
+				<xs:annotation>
+					<xs:documentation>In Analogie zu REC_ORT aus VDV 452</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BeaconPoint" type="BeaconPointStructure"/>
+			<xs:element name="GNSSLocationPoint" type="GNSSPointStructure">
+				<xs:annotation>
+					<xs:documentation>Point, where specific GNSS-Information is provided, "GNSS-Solution" for the Beacon-Points, analogue to REC_OM from VDV 452</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="TimingPoint" type="TimingPointStructure"/>
+			<xs:element name="TSPPoint" type="TSPPointStructure">
+				<xs:annotation>
+					<xs:documentation>Point, where Information for TrafficSignalPriorisation is provided </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="SpecificPointStructure">
+		<xs:sequence>
+			<xs:element name="PointRef" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="DistanceToPreviousPoint" type="IBIS-IP.double"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceSpecificationStructure">
+		<xs:sequence>
+			<xs:element name="ServiceName" type="ServiceNameEnumeration"/>
+			<xs:element name="IBIS-IP-Version" type="IBIS-IP.NMTOKEN"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceSpecificationWithStateStructure">
+		<xs:sequence>
+			<xs:element name="ServiceSpecification" type="ServiceSpecificationStructure"/>
+			<xs:element name="ServiceState" type="ServiceStateEnumeration"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceSpecificationWithStateListStructure">
+		<xs:sequence>
+			<xs:element name="ServiceSpecificationWithState" type="ServiceSpecificationWithStateStructure" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceIdentificationStructure">
+		<xs:sequence>
+			<xs:element name="Service" type="ServiceSpecificationStructure"/>
+			<xs:element name="Device" type="DeviceSpecificationStructure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceIdentificationWithStateStructure">
+		<xs:sequence>
+			<xs:element name="ServiceIdentification" type="ServiceIdentificationStructure"/>
+			<xs:element name="ServiceState" type="ServiceStateEnumeration"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceIdentificationWithStateListStructure">
+		<xs:sequence>
+			<xs:element name="ServiceIdentificationWithState" type="ServiceIdentificationWithStateStructure" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceInformationListStructure">
+		<xs:sequence>
+			<xs:element name="ServiceInformation" type="ServiceInformationStructure" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceInformationStructure">
+		<xs:sequence>
+			<xs:element name="Service" type="ServiceSpecificationStructure"/>
+			<xs:element name="Autostart" type="IBIS-IP.boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceStartStructure">
+		<xs:sequence>
+			<xs:element name="ServiceIdentification" type="ServiceIdentificationStructure"/>
+			<xs:element name="Autostart" type="IBIS-IP.boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceStartListStructure">
+		<xs:sequence>
+			<xs:element name="ServiceIdentification" type="ServiceIdentificationStructure" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ShortTripStopListStructure">
+		<xs:sequence>
+			<xs:element name="ShortTripStop" type="ShortTripStopStructure" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ShortTripStopStructure">
+		<xs:sequence>
+			<xs:element name="JourneyStopInformation" type="JourneyStopInformationStructure"/>
+			<xs:element name="FareZoneInformation" type="FareZoneInformationStructure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StopInformationRequestStructure">
+		<xs:sequence>
+			<xs:element name="StopIndex" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>StopIndex on current trip	</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="StopRef" type="IBIS-IP.NMTOKEN" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Reference to the stoppoint from the planning system	</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="StopName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="DisplayContent" type="DisplayContentStructure" maxOccurs="unbounded"/>
+			<xs:element name="StopAnnouncement" type="AnnouncementStructure" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ArrivalScheduled" type="IBIS-IP.dateTime" minOccurs="0"/>
+			<xs:element name="DepartureScheduled" type="IBIS-IP.dateTime" minOccurs="0"/>
+			<xs:element name="RecordedArrivalTime" type="IBIS-IP.dateTime" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>This Value is needed for the demonstration at the SSB</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DistanceToNextStop" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Soll-Abstand zwischen den Haltestellen</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Connection" type="ConnectionStructure" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Information on Connections or Interchanges; not in StopSequence because of RealTimeInformation</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="FareZone" type="IBIS-IP.NMTOKEN" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StopInformationStructure">
+		<xs:sequence>
+			<xs:element name="StopIndex" type="IBIS-IP.int">
+				<xs:annotation>
+					<xs:documentation>StopIndex on current trip	</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="StopRef" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>Reference to the stoppoint from the planning system	</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="StopName" type="InternationalTextType" maxOccurs="unbounded"/>
+			<xs:element name="StopAlternativeName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Platform" type="IBIS-IP.string" minOccurs="0"/>
+			<xs:element name="DisplayContent" type="DisplayContentStructure" maxOccurs="unbounded"/>
+			<xs:element name="StopAnnouncement" type="AnnouncementStructure" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ArrivalScheduled" type="IBIS-IP.dateTime" minOccurs="0"/>
+			<xs:element name="ArrivalExpected" type="IBIS-IP.dateTime" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>A resolution of 30s is recommended, for the display it is recommended to show the arrival time in minutes.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DepartureScheduled" type="IBIS-IP.dateTime" minOccurs="0"/>
+			<xs:element name="DepartureExpected" type="IBIS-IP.dateTime" minOccurs="0"/>
+			<xs:element name="RecordedArrivalTime" type="IBIS-IP.dateTime" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>This Value is needed for the demonstration at the SSB</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DistanceToNextStop" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Soll-Abstand zwischen den Haltestellen</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Connection" type="ConnectionStructure" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Information on Connections or Interchanges; not in StopSequence because of RealTimeInformation</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="FareZone" type="IBIS-IP.NMTOKEN" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StopPointTariffInformationStructure">
+		<xs:sequence>
+			<xs:element name="JourneyStopInformation" type="JourneyStopInformationStructure"/>
+			<xs:element name="FareZoneInformation" type="FareZoneInformationStructure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StopSequenceStructure">
+		<xs:sequence>
+			<xs:element name="StopPoint" type="StopInformationStructure" minOccurs="2" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TimingPointStructure">
+		<xs:sequence>
+			<xs:element name="TimingPointRef" type="IBIS-IP.NMTOKEN" minOccurs="0"/>
+			<xs:element name="ScheduleTime" type="IBIS-IP.dateTime"/>
+			<xs:element name="GNSSPoint" type="GNSSPointStructure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TripInformationStructure">
+		<xs:sequence>
+			<xs:element name="TripRef" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="StopSequence" type="StopSequenceStructure">
+				<xs:annotation>
+					<xs:documentation>List of StopPoints; with additional information</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="LocationState" type="LocationStateEnumeration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Information of the location state</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="TimetableDelay" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Delay in seconds. Early times are shown as negative values.</xs:documentation>
+					<xs:documentation>
+            			tbd: what happens, if this value isn't set
+            		</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalTextMessage" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalTextMessage1" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalTextMessage2" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalTextMessage3" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalTextMessage4" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalTextMessage5" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalTextMessage6" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalTextMessage7" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalTextMessage8" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalTextMessage9" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalAnnouncement" type="AdditionalAnnouncementStructure" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>not StopPointAnnouncements; additional announcements; e.g. of the operator or dispatcher</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="RouteDirection" type="RouteDirectionEnumeration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The direction of the route, 1->forward 2->backwards and  0->UNDEFINED </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="RunNumber" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The run number (Kurs-Nummer) the trip is operated </xs:documentation>
+				</xs:annotation>
+			</xs:element>						
+			<xs:element name="PatternNumber" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The pattern number (Linienfahrweg-Nummer) the trip is operated </xs:documentation>
+				</xs:annotation>
+			</xs:element>						
+			<xs:element name="PathDestinationNumber" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The path destination number (RoutenZiel-Nummer) the trip is operated </xs:documentation>
+				</xs:annotation>
+			</xs:element>									
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TripSequenceStructure">
+		<xs:sequence>
+			<xs:element name="TripRef" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="TripIndex" type="IBIS-IP.int" minOccurs="0"/>
+			<xs:element name="TripStart" type="IBIS-IP.time" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Time, at which the trip is starting</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CurrentStopIndex" type="IBIS-IP.int" minOccurs="0"/>
+			<xs:element name="JourneyMode" type="JourneyModeEnumeration" minOccurs="0"/>
+			<xs:element name="PointSequence" type="PointSequenceStructure">
+				<xs:annotation>
+					<xs:documentation>In Analogie zu LID-Verlauf aus VDV 452</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TSPPointStructure">
+		<xs:sequence>
+			<xs:element name="TSPPointRef" type="IBIS-IP.NMTOKEN" minOccurs="0"/>
+			<xs:element name="TSPCode" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="ShortName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Desciption" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="VehicleStructure">
+		<xs:sequence>
+			<xs:element name="VehicleTypeRef" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="Name" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ViaPointStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for describing a via point on journey.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ViaPointRef" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="PlaceRef" type="IBIS-IP.NMTOKEN" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The identifier of the via place in the journey; used to help identify the vehicle journey on arrival boards.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PlaceName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>The name of the via place in the journey; used to help identify the vehicle to the public.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PlaceShortName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>The short name of the via place in the journey; used to help identify the vehicle to the public.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ViaPointDisplayPriority" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Value, which defines a priority to select a number of via points, if not all via points can be shown</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ZoneType">
+		<xs:sequence>
+			<xs:element name="FarezoneTypeID" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="FareZoneTypeName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--==== DataTypes ====-->
+	<xs:complexType name="InternationalTextType">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:string"/>
+			<xs:element name="Language" type="xs:language"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DoorCountingListStructure">
+		<xs:sequence>
+			<xs:element name="DoorID" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="CountSet" type="DoorCountingStructure" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DoorCountingStructure">
+		<xs:sequence>
+			<xs:element name="ObjectClass" type="DoorCountingObjectClassEnumeration"/>
+			<xs:element name="In" type="IBIS-IP.int"/>
+			<xs:element name="Out" type="IBIS-IP.int"/>
+			<xs:element name="CountQuality" type="DoorCountingQualityEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DoorInformationStructure">
+		<xs:sequence>
+			<xs:element name="DoorID" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="Count" type="DoorCountingStructure" maxOccurs="unbounded"/>
+			<xs:element name="State" type="DoorStateStructure" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DoorOpenStateStructure">
+		<xs:sequence>
+			<xs:element name="Value" type="DoorOpenStateEnumeration"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DoorOperationStateStructure">
+		<xs:sequence>
+			<xs:element name="Value" type="DoorOperationStateEnumeration"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DoorStateStructure">
+		<xs:sequence>
+			<xs:element name="OpenState" type="DoorOpenStateStructure"/>
+			<xs:element name="OperationState" type="DoorOperationStateStructure" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--==== IBIS-IP-Types ====-->
+	<xs:complexType name="DegreeType">
+		<xs:sequence>
+			<xs:element name="Degree" type="IBIS-IP.double"/>
+			<xs:element name="Orientation" type="IBIS-IP.string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.anyURI">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:anyURI"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.boolean">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:boolean"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.byte">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:byte"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.date">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:date"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.dateTime">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:dateTime"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.double">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:double"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.duration">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:duration"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.int">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:int"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.language">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:language"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.NMTOKEN">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:NMTOKEN"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.nonNegativeInteger">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:nonNegativeInteger"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.normalizedString">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:normalizedString"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.string">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:string"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.time">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:time"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.unsignedInt">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:unsignedInt"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.unsignedLong">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:unsignedLong"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--==== StructureDefinitions ====-->
+	<xs:element name="SubscribeRequest" type="SubscribeRequestStructure"/>
+	<xs:complexType name="SubscribeRequestStructure">
+		<xs:sequence>
+			<xs:element name="Client-IP-Address" type="IBIS-IP.string"/>
+			<xs:element name="ReplyPort" type="IBIS-IP.int" minOccurs="0"/>
+			<xs:element name="ReplyPath" type="IBIS-IP.string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="SubscribeResponse" type="SubscribeResponseStructure"/>
+	<xs:complexType name="SubscribeResponseStructure">
+		<xs:annotation>
+			<xs:documentation>For compatibility reasons, this structure is now a sequence of members, all of which are optional - of course, at least one member should be included in meaningful data.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Active" type="IBIS-IP.boolean" minOccurs="0"/>
+			<xs:element name="Heartbeat" type="IBIS-IP.duration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If the service returns a heartbeat value and it is not 0, the subscriber can expect that the service will send data at least every heartbeat seconds.	This heartbeat can be used to monitor the connection quality by the client. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="UnsubscribeRequest" type="UnsubscribeRequestStructure"/>
+	<xs:complexType name="UnsubscribeRequestStructure">
+		<xs:sequence>
+			<xs:element name="Client-IP-Address" type="IBIS-IP.string"/>
+			<xs:element name="ReplyPort" type="IBIS-IP.int" minOccurs="0"/>
+			<xs:element name="ReplyPath" type="IBIS-IP.string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="UnsubscribeResponse" type="UnsubscribeResponseStructure"/>
+	<xs:complexType name="UnsubscribeResponseStructure">
+		<xs:sequence>
+			<xs:element name="Active" type="IBIS-IP.boolean"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="DataAcceptedResponse" type="DataAcceptedResponseStructure"/>
+	<xs:complexType name="DataAcceptedResponseStructure">
+		<xs:choice>
+			<xs:element name="DataAcceptedResponseData" type="DataAcceptedResponseDataStructure"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="DataAcceptedResponseDataStructure">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="DataAccepted" type="IBIS-IP.boolean"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+			<xs:element name="ErrorInformation" type="IBIS-IP.string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--==== GroupDefinitions ====-->
+	<xs:group name="DeviceInformationGroup">
+		<xs:sequence>
+			<xs:element name="DeviceName" type="IBIS-IP.string"/>
+			<xs:element name="Manufacturer" type="IBIS-IP.string"/>
+			<xs:element name="SerialNumber" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="DeviceClass" type="DeviceClassEnumeration"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="DisplayPolicyGroup">
+		<xs:sequence>
+			<xs:element name="Priority" type="IBIS-IP.nonNegativeInteger" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Value, which allows to decide which Information is shown, if there is not enough time to show all</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PeriodDuration" type="IBIS-IP.duration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If more than one Sign-Information is given, you need to know</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Duration" type="IBIS-IP.duration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Time-Value, which defines the part of the Periodtime in which this Sign-Information should be shown</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:group>
+	<xs:complexType name="NetexMode">
+		<xs:annotation>
+			<xs:documentation>a combined Mode and SubMode information in accordance with Netex "netex_submode_version.xsd"</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:choice minOccurs="0">
+				<xs:element name="PtMainMode" type="PtSubModesEnumeration" minOccurs="0"/>
+				<xs:element name="PrivateMainMode" type="PrivateSubModesEnumeration" minOccurs="0"/>
+			</xs:choice>
+			<xs:choice minOccurs="0">
+				<xs:group ref="PtSubmodeChoiceGroup" minOccurs="0"/>
+				<xs:group ref="PrivateSubmodeChoiceGroup" minOccurs="0"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/IBIS-IP_common_V2.4.xsd
+++ b/IBIS-IP_common_V2.4.xsd
@@ -1,0 +1,1061 @@
+<?xml version="1.0"?>
+<!-- Mit XMLSpy v2012 rel. 2 sp1 (http://www.altova.com) von Dirk Weißer (INIT GmbH) bearbeitet -->
+<!-- Mit XMLSpy v2018 rel. 2  (http://www.altova.com) von Bernd Schubert (iris-GmbH) bearbeitet, IBIS-IP 2.1 -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="IBIS-IP_Enumerations_V2.2.xsd"/>
+	<!--==== DataDefinitions ====-->
+	<xs:complexType name="AdditionalAnnouncementStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for decscribing the informations for an additional announcement</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="AnnouncementRef" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>Reference to the Announcement in the schedule data</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AnnouncementText" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Text of the Announcement</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AnnouncementTTSText" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Text of the Announcement for a text-to-speech-system</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice minOccurs="0">
+				<xs:element name="ImmediateInformation" type="IBIS-IP.boolean">
+					<xs:annotation>
+						<xs:documentation>true, if the additional annoucement should be pronounced immiditaley</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="PeriodicalInformation" type="IBIS-IP.duration">
+					<xs:annotation>
+						<xs:documentation>period in which the addional announcement should be played </xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="SpecificPoint" type="SpecificPointStructure">
+					<xs:annotation>
+						<xs:documentation>describes a specific point, where the addional announcement should be played</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="AnnouncementStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for decscribing the informations for an regular announcement</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="AnnouncementRef" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>Reference to the Announcement in the schedule data</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AnnouncementText" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Text of the Announcement</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AnnouncementTTSText" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Text of the Announcement for a text-to-speech-system</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BayAreaStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for describing an area at the stop point for detecting the right stop position</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="BeforeBay" type="IBIS-IP.double" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Distance before the defined Stoppoint, where the detection area begins, value in [m]</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BehindBay" type="IBIS-IP.double" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Distance behind the defined Stoppoint, where the detection area begins, value in [m]</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BeaconPointStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for describing a beacon point</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="PointRef" type="IBIS-IP.NMTOKEN" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Reference to the beacon point in the schedule data</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BeaconCode" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>Code of the beacon point</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ShortName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Shortname of the beaon point</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Desciption" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Text, which gives some additional information on the beacon point</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CardApplInformations">
+		<xs:sequence>
+			<xs:element name="CardApplInformationLength" type="IBIS-IP.unsignedInt">
+				<xs:annotation>
+					<xs:documentation>Length of the bytearray of applikationdata</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CardApplInformationData" type="IBIS-IP.byte" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Applikationdata from Card as Byte-Array </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CardTicketData">
+		<xs:sequence>
+			<xs:element name="CardTicketDataID" type="IBIS-IP.unsignedLong"/>
+			<xs:element name="CardTicketDataLength" type="IBIS-IP.unsignedInt">
+				<xs:annotation>
+					<xs:documentation>Length of the bytearray of ticketdata</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CardTicketData" type="IBIS-IP.byte" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Ticketdata from Card as  Byte-Array</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CardType">
+		<xs:sequence>
+			<xs:element name="CardSerialNumber" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="CardTypeID" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="CardTypeText" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ConnectionStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for describing a connection</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="StopRef" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>StopPoint, where the connection should take place (from planning system)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ConnectionRef" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>StopPoint-referenced connection-reference</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ConnectionType" type="ConnectionTypeEnumeration">
+				<xs:annotation>
+					<xs:documentation>Describes the kind of connection </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DisplayContent" type="DisplayContentStructure" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Structure for desccribing the information which is shown on a head- or sidesign</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Platform" type="IBIS-IP.string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Platform, on which the connection should take place</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ConnectionState" type="ConnectionStateEnumeration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Describes the status of the connection</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="TransportMode" type="VehicleStructure" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Describes the mode of the pick-up vehicle, DEPRECATED !, THE ConnectionMode SHOULD BE USED INSTEAD</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ConnectionMode" type="NetexMode" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Mode- and Submode information of the pick-up vehicle in accordance with Netex</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ExpectedDepartureTime" type="IBIS-IP.dateTime" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Information, at which time the leaving vehicle will depart based on realtime information</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ScheduledDepartureTime" type="IBIS-IP.dateTime" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Information, at which time the leaving vehicle is planned to depart</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DataVersionStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for describing data-versions</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="DataType" type="IBIS-IP.string">
+				<xs:annotation>
+					<xs:documentation>Kind of data</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="VersionRef" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>Versionreference of the data</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DataVersionListStructure">
+		<xs:sequence>
+			<xs:element name="DataVersion" type="DataVersionStructure" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DestinationStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for describing destination information</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="DestinationRef" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>Reference to the destination-information in the schedule-data</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DestinationName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Text of the destination</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DestinationShortName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Shorttext of the destination if there is limited space</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DeviceInformationStructure">
+		<xs:sequence>
+			<xs:group ref="DeviceInformationGroup"/>
+			<xs:element name="DataVersionList" type="DataVersionListStructure" minOccurs="0"/>
+			<xs:element name="WebInterfaceAddress" type="IBIS-IP.anyURI" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DeviceSpecificationListStructure">
+		<xs:sequence>
+			<xs:element name="DeviceSpecification" type="DeviceSpecificationStructure" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DeviceSpecificationStructure">
+		<xs:sequence>
+			<xs:element name="DeviceClass" type="DeviceClassEnumeration"/>
+			<xs:element name="DeviceID" type="IBIS-IP.NMTOKEN"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DeviceSpecificationWithStateStructure">
+		<xs:sequence>
+			<xs:element name="DeviceSpecification" type="DeviceSpecificationStructure"/>
+			<xs:element name="DeviceState" type="DeviceStateEnumeration"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DeviceSpecificationWithStateListStructure">
+		<xs:sequence>
+			<xs:element name="DeviceSpecificationWithState" type="DeviceSpecificationWithStateStructure" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DisplayContentStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for describing the information for a headsign or a sidesign</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="DisplayContentRef" type="IBIS-IP.NMTOKEN" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Reference to the display content information in the schedule data</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="LineInformation" type="LineInformationStructure">
+				<xs:annotation>
+					<xs:documentation>Information on the line, which should be displayed</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Destination" type="DestinationStructure">
+				<xs:annotation>
+					<xs:documentation>Information on the destination, which should be displayed</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ViaPoint" type="ViaPointStructure" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Information on the via points which should be displayed</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which could be displayed, e.g. "Extra Ride", "Express", ... </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation1" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which is assigned project-specific</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation2" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which is assigned project-specific</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation3" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which is assigned project-specific</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation4" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which is assigned project-specific</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation5" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which is assigned project-specific</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation6" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which is assigned project-specific</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation7" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which is assigned project-specific</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation8" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which is assigned project-specific</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalInformation9" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Additional Information Text, which is assigned project-specific</xs:documentation>
+				</xs:annotation>
+			</xs:element>		
+			<xs:element name="RunNumber" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The run number (Kurs-Nummer) the trip is operated </xs:documentation>
+				</xs:annotation>
+			</xs:element>								
+			<xs:group ref="DisplayPolicyGroup" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Group for Display-Information if there is more than one content at the same time</xs:documentation>
+				</xs:annotation>
+			</xs:group>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FareZoneInformationStructure">
+		<xs:sequence>
+			<xs:element name="FareZoneID" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>unique ID for the farezone</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="FareZoneType" type="ZoneType" minOccurs="0"/>
+			<xs:element name="FareZoneLongName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="FareZoneShortName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GlobalCardStatus">
+		<xs:sequence>
+			<xs:element name="GlobalCardStausID" type="IBIS-IP.unsignedInt">
+				<xs:annotation>
+					<xs:documentation>code according EN 1545</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="GlobalCardStatusText" type="IBIS-IP.string" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>text according EN 1545</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GNSSPointStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for describing a GNSS-Point</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="PointRef" type="IBIS-IP.NMTOKEN" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Reference to the point in schedule data</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Longitude" type="GNSSCoordinateStructure"/>
+			<xs:element name="Latitude" type="GNSSCoordinateStructure"/>
+			<xs:element name="Altitude" type="IBIS-IP.double" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GNSSCoordinateStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for describing a GNSS-Point</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Degree" type="IBIS-IP.double"/>
+			<xs:element name="Direction" type="IBIS-IP.string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="JourneyStopInformationStructure">
+		<xs:sequence>
+			<xs:element name="StopRef" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>Reference to the stoppoint from the planning system	</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="StopName" type="InternationalTextType" maxOccurs="unbounded"/>
+			<xs:element name="StopAlternativeName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Platform" type="IBIS-IP.string" minOccurs="0"/>
+			<xs:element name="DisplayContent" type="DisplayContentStructure" maxOccurs="unbounded"/>
+			<xs:element name="Announcement" type="AnnouncementStructure" minOccurs="0"/>
+			<xs:element name="ArrivalScheduled" type="IBIS-IP.dateTime" minOccurs="0"/>
+			<xs:element name="DepartureScheduled" type="IBIS-IP.dateTime" minOccurs="0"/>
+			<xs:element name="Connection" type="ConnectionStructure" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Information on Connections or Interchanges; not in StopSequence because of RealTimeInformation</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BayArea" type="BayAreaStructure" minOccurs="0"/>
+			<xs:element name="GNSSPoint" type="GNSSPointStructure" minOccurs="0"/>
+			<xs:element name="FareZone" type="IBIS-IP.NMTOKEN" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LineInformationStructure">
+		<xs:sequence>
+			<xs:element name="LineRef" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="LineName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="LineShortName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="LineNumber" type="IBIS-IP.int" minOccurs="0"/>
+			<xs:element name="LineCode" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>identifier of a symbol number , which is used by displays see LINIEN_CODE in VDV 452 chapter 9.7.2 REC_LID</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="LinePublicCode" type="IBIS-IP.string" minOccurs="0" maxOccurs="1"/>			
+			<xs:element name="LineSymbolText" type="IBIS-IP.string" minOccurs="0" maxOccurs="1"/>			
+			<xs:element name="ExternalLineRef" type="IBIS-IP.string" minOccurs="0" maxOccurs="1"/>			
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="LogMessageStructure">
+		<xs:sequence>
+			<xs:element name="MessageProvider" type="DeviceSpecificationStructure">
+				<xs:annotation>
+					<xs:documentation>Name of the Service or Device, which sends the message, which has to be logged</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Message" type="MessageStructure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="MessageStructure">
+		<xs:sequence>
+			<xs:element name="Message-ID" type="IBIS-IP.int"/>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime">
+				<xs:annotation>
+					<xs:documentation>... of the ErrorMessage</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="MessageType" type="MessageTypeEnumeration"/>
+			<xs:element name="MessageText" type="IBIS-IP.string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PointSequenceStructure">
+		<xs:sequence>
+			<xs:element name="Point" type="PointStructure" minOccurs="2" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PointStructure">
+		<xs:sequence>
+			<xs:element name="PointIndex" type="IBIS-IP.int"/>
+			<xs:element name="PointType" type="PointTypeStructure"/>
+			<xs:element name="DistanceToPreviousPoint" type="IBIS-IP.int">
+				<xs:annotation>
+					<xs:documentation>aus REC-SEL bzw. REC_SEL_ZP der VDV 452</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PointTypeStructure">
+		<xs:choice>
+			<xs:element name="StopPoint" type="JourneyStopInformationStructure">
+				<xs:annotation>
+					<xs:documentation>In Analogie zu REC_ORT aus VDV 452</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BeaconPoint" type="BeaconPointStructure"/>
+			<xs:element name="GNSSLocationPoint" type="GNSSPointStructure">
+				<xs:annotation>
+					<xs:documentation>Point, where specific GNSS-Information is provided, "GNSS-Solution" for the Beacon-Points, analogue to REC_OM from VDV 452</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="TimingPoint" type="TimingPointStructure"/>
+			<xs:element name="TSPPoint" type="TSPPointStructure">
+				<xs:annotation>
+					<xs:documentation>Point, where Information for TrafficSignalPriorisation is provided </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="SpecificPointStructure">
+		<xs:sequence>
+			<xs:element name="PointRef" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="DistanceToPreviousPoint" type="IBIS-IP.double"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceSpecificationStructure">
+		<xs:sequence>
+			<xs:element name="ServiceName" type="ServiceNameEnumeration"/>
+			<xs:element name="IBIS-IP-Version" type="IBIS-IP.NMTOKEN"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceSpecificationWithStateStructure">
+		<xs:sequence>
+			<xs:element name="ServiceSpecification" type="ServiceSpecificationStructure"/>
+			<xs:element name="ServiceState" type="ServiceStateEnumeration"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceSpecificationWithStateListStructure">
+		<xs:sequence>
+			<xs:element name="ServiceSpecificationWithState" type="ServiceSpecificationWithStateStructure" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceIdentificationStructure">
+		<xs:sequence>
+			<xs:element name="Service" type="ServiceSpecificationStructure"/>
+			<xs:element name="Device" type="DeviceSpecificationStructure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceIdentificationWithStateStructure">
+		<xs:sequence>
+			<xs:element name="ServiceIdentification" type="ServiceIdentificationStructure"/>
+			<xs:element name="ServiceState" type="ServiceStateEnumeration"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceIdentificationWithStateListStructure">
+		<xs:sequence>
+			<xs:element name="ServiceIdentificationWithState" type="ServiceIdentificationWithStateStructure" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceInformationListStructure">
+		<xs:sequence>
+			<xs:element name="ServiceInformation" type="ServiceInformationStructure" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceInformationStructure">
+		<xs:sequence>
+			<xs:element name="Service" type="ServiceSpecificationStructure"/>
+			<xs:element name="Autostart" type="IBIS-IP.boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceStartStructure">
+		<xs:sequence>
+			<xs:element name="ServiceIdentification" type="ServiceIdentificationStructure"/>
+			<xs:element name="Autostart" type="IBIS-IP.boolean"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ServiceStartListStructure">
+		<xs:sequence>
+			<xs:element name="ServiceIdentification" type="ServiceIdentificationStructure" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ShortTripStopListStructure">
+		<xs:sequence>
+			<xs:element name="ShortTripStop" type="ShortTripStopStructure" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ShortTripStopStructure">
+		<xs:sequence>
+			<xs:element name="JourneyStopInformation" type="JourneyStopInformationStructure"/>
+			<xs:element name="FareZoneInformation" type="FareZoneInformationStructure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StopInformationRequestStructure">
+		<xs:sequence>
+			<xs:element name="StopIndex" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>StopIndex on current trip	</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="StopRef" type="IBIS-IP.NMTOKEN" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Reference to the stoppoint from the planning system	</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="StopName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="DisplayContent" type="DisplayContentStructure" maxOccurs="unbounded"/>
+			<xs:element name="StopAnnouncement" type="AnnouncementStructure" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ArrivalScheduled" type="IBIS-IP.dateTime" minOccurs="0"/>
+			<xs:element name="DepartureScheduled" type="IBIS-IP.dateTime" minOccurs="0"/>
+			<xs:element name="RecordedArrivalTime" type="IBIS-IP.dateTime" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>This Value is needed for the demonstration at the SSB</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DistanceToNextStop" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Soll-Abstand zwischen den Haltestellen</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Connection" type="ConnectionStructure" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Information on Connections or Interchanges; not in StopSequence because of RealTimeInformation</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="FareZone" type="IBIS-IP.NMTOKEN" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StopInformationStructure">
+		<xs:sequence>
+			<xs:element name="StopIndex" type="IBIS-IP.int">
+				<xs:annotation>
+					<xs:documentation>StopIndex on current trip	</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="StopRef" type="IBIS-IP.NMTOKEN">
+				<xs:annotation>
+					<xs:documentation>Reference to the stoppoint from the planning system	</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="StopName" type="InternationalTextType" maxOccurs="unbounded"/>
+			<xs:element name="StopAlternativeName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Platform" type="IBIS-IP.string" minOccurs="0"/>
+			<xs:element name="DisplayContent" type="DisplayContentStructure" maxOccurs="unbounded"/>
+			<xs:element name="StopAnnouncement" type="AnnouncementStructure" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ArrivalScheduled" type="IBIS-IP.dateTime" minOccurs="0"/>
+			<xs:element name="ArrivalExpected" type="IBIS-IP.dateTime" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>A resolution of 30s is recommended, for the display it is recommended to show the arrival time in minutes.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DepartureScheduled" type="IBIS-IP.dateTime" minOccurs="0"/>
+			<xs:element name="DepartureExpected" type="IBIS-IP.dateTime" minOccurs="0"/>
+			<xs:element name="RecordedArrivalTime" type="IBIS-IP.dateTime" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>This Value is needed for the demonstration at the SSB</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DistanceToNextStop" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Soll-Abstand zwischen den Haltestellen</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Connection" type="ConnectionStructure" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Information on Connections or Interchanges; not in StopSequence because of RealTimeInformation</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="FareZone" type="IBIS-IP.NMTOKEN" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="StopShortName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="StopLongNo" type="IBIS-IP.int" minOccurs="0" maxOccurs="1"/>			
+			<xs:element name="PointNumber" type="IBIS-IP.int" minOccurs="0" maxOccurs="1"/>			
+			<xs:element name="StopGlobalID" type="IBIS-IP.string" minOccurs="0" maxOccurs="1"/>			
+			<xs:element name="StopPointGlobalID" type="IBIS-IP.string" minOccurs="0" maxOccurs="1"/>						
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StopPointTariffInformationStructure">
+		<xs:sequence>
+			<xs:element name="JourneyStopInformation" type="JourneyStopInformationStructure"/>
+			<xs:element name="FareZoneInformation" type="FareZoneInformationStructure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StopSequenceStructure">
+		<xs:sequence>
+			<xs:element name="StopPoint" type="StopInformationStructure" minOccurs="2" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TimingPointStructure">
+		<xs:sequence>
+			<xs:element name="TimingPointRef" type="IBIS-IP.NMTOKEN" minOccurs="0"/>
+			<xs:element name="ScheduleTime" type="IBIS-IP.dateTime"/>
+			<xs:element name="GNSSPoint" type="GNSSPointStructure"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TripInformationStructure">
+		<xs:sequence>
+			<xs:element name="TripRef" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="StopSequence" type="StopSequenceStructure">
+				<xs:annotation>
+					<xs:documentation>List of StopPoints; with additional information</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="LocationState" type="LocationStateEnumeration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Information of the location state</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="TimetableDelay" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Delay in seconds. Early times are shown as negative values.</xs:documentation>
+					<xs:documentation>
+            			tbd: what happens, if this value isn't set
+            		</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AdditionalTextMessage" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalTextMessage1" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalTextMessage2" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalTextMessage3" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalTextMessage4" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalTextMessage5" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalTextMessage6" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalTextMessage7" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalTextMessage8" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalTextMessage9" type="InternationalTextType" minOccurs="0"/>
+			<xs:element name="AdditionalAnnouncement" type="AdditionalAnnouncementStructure" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>not StopPointAnnouncements; additional announcements; e.g. of the operator or dispatcher</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="RouteDirection" type="RouteDirectionEnumeration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The direction of the route, 1->forward 2->backwards and  0->UNDEFINED </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="RunNumber" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The run number (Kurs-Nummer) the trip is operated </xs:documentation>
+				</xs:annotation>
+			</xs:element>						
+			<xs:element name="PatternNumber" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The pattern number (Linienfahrweg-Nummer) the trip is operated </xs:documentation>
+				</xs:annotation>
+			</xs:element>						
+			<xs:element name="PathDestinationNumber" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The path destination number (RoutenZiel-Nummer) the trip is operated </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BlockNumber" type="IBIS-IP.int"  minOccurs="0" maxOccurs="1"/>						
+			<xs:element name="ExternalVehicleJourneyRef" type="IBIS-IP.string"  minOccurs="0" maxOccurs="1"/>			
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TripSequenceStructure">
+		<xs:sequence>
+			<xs:element name="TripRef" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="TripIndex" type="IBIS-IP.int" minOccurs="0"/>
+			<xs:element name="TripStart" type="IBIS-IP.time" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Time, at which the trip is starting</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CurrentStopIndex" type="IBIS-IP.int" minOccurs="0"/>
+			<xs:element name="JourneyMode" type="JourneyModeEnumeration" minOccurs="0"/>
+			<xs:element name="PointSequence" type="PointSequenceStructure">
+				<xs:annotation>
+					<xs:documentation>In Analogie zu LID-Verlauf aus VDV 452</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TSPPointStructure">
+		<xs:sequence>
+			<xs:element name="TSPPointRef" type="IBIS-IP.NMTOKEN" minOccurs="0"/>
+			<xs:element name="TSPCode" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="ShortName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Desciption" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="VehicleStructure">
+		<xs:sequence>
+			<xs:element name="VehicleTypeRef" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="Name" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ViaPointStructure">
+		<xs:annotation>
+			<xs:documentation>Structure for describing a via point on journey.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ViaPointRef" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="PlaceRef" type="IBIS-IP.NMTOKEN" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The identifier of the via place in the journey; used to help identify the vehicle journey on arrival boards.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PlaceName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>The name of the via place in the journey; used to help identify the vehicle to the public.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PlaceShortName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>The short name of the via place in the journey; used to help identify the vehicle to the public.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ViaPointDisplayPriority" type="IBIS-IP.int" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Value, which defines a priority to select a number of via points, if not all via points can be shown</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ZoneType">
+		<xs:sequence>
+			<xs:element name="FarezoneTypeID" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="FareZoneTypeName" type="InternationalTextType" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--==== DataTypes ====-->
+	<xs:complexType name="InternationalTextType">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:string"/>
+			<xs:element name="Language" type="xs:language"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DoorCountingListStructure">
+		<xs:sequence>
+			<xs:element name="DoorID" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="CountSet" type="DoorCountingStructure" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DoorCountingStructure">
+		<xs:sequence>
+			<xs:element name="ObjectClass" type="DoorCountingObjectClassEnumeration"/>
+			<xs:element name="In" type="IBIS-IP.int"/>
+			<xs:element name="Out" type="IBIS-IP.int"/>
+			<xs:element name="CountQuality" type="DoorCountingQualityEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DoorInformationStructure">
+		<xs:sequence>
+			<xs:element name="DoorID" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="Count" type="DoorCountingStructure" maxOccurs="unbounded"/>
+			<xs:element name="State" type="DoorStateStructure" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DoorOpenStateStructure">
+		<xs:sequence>
+			<xs:element name="Value" type="DoorOpenStateEnumeration"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DoorOperationStateStructure">
+		<xs:sequence>
+			<xs:element name="Value" type="DoorOperationStateEnumeration"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DoorStateStructure">
+		<xs:sequence>
+			<xs:element name="OpenState" type="DoorOpenStateStructure"/>
+			<xs:element name="OperationState" type="DoorOperationStateStructure" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--==== IBIS-IP-Types ====-->
+	<xs:complexType name="DegreeType">
+		<xs:sequence>
+			<xs:element name="Degree" type="IBIS-IP.double"/>
+			<xs:element name="Orientation" type="IBIS-IP.string"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.anyURI">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:anyURI"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.boolean">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:boolean"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.byte">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:byte"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.date">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:date"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.dateTime">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:dateTime"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.double">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:double"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.duration">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:duration"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.int">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:int"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.language">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:language"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.NMTOKEN">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:NMTOKEN"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.nonNegativeInteger">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:nonNegativeInteger"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.normalizedString">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:normalizedString"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.string">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:string"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.time">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:time"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.unsignedInt">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:unsignedInt"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IBIS-IP.unsignedLong">
+		<xs:sequence>
+			<xs:element name="Value" type="xs:unsignedLong"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--==== StructureDefinitions ====-->
+	<xs:element name="SubscribeRequest" type="SubscribeRequestStructure"/>
+	<xs:complexType name="SubscribeRequestStructure">
+		<xs:sequence>
+			<xs:element name="Client-IP-Address" type="IBIS-IP.string"/>
+			<xs:element name="ReplyPort" type="IBIS-IP.int" minOccurs="0"/>
+			<xs:element name="ReplyPath" type="IBIS-IP.string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="SubscribeResponse" type="SubscribeResponseStructure"/>
+	<xs:complexType name="SubscribeResponseStructure">
+		<xs:annotation>
+			<xs:documentation>For compatibility reasons, this structure is now a sequence of members, all of which are optional - of course, at least one member should be included in meaningful data.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Active" type="IBIS-IP.boolean" minOccurs="0"/>
+			<xs:element name="Heartbeat" type="IBIS-IP.duration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If the service returns a heartbeat value and it is not 0, the subscriber can expect that the service will send data at least every heartbeat seconds.	This heartbeat can be used to monitor the connection quality by the client. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="UnsubscribeRequest" type="UnsubscribeRequestStructure"/>
+	<xs:complexType name="UnsubscribeRequestStructure">
+		<xs:sequence>
+			<xs:element name="Client-IP-Address" type="IBIS-IP.string"/>
+			<xs:element name="ReplyPort" type="IBIS-IP.int" minOccurs="0"/>
+			<xs:element name="ReplyPath" type="IBIS-IP.string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="UnsubscribeResponse" type="UnsubscribeResponseStructure"/>
+	<xs:complexType name="UnsubscribeResponseStructure">
+		<xs:sequence>
+			<xs:element name="Active" type="IBIS-IP.boolean"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="DataAcceptedResponse" type="DataAcceptedResponseStructure"/>
+	<xs:complexType name="DataAcceptedResponseStructure">
+		<xs:choice>
+			<xs:element name="DataAcceptedResponseData" type="DataAcceptedResponseDataStructure"/>
+			<xs:element name="OperationErrorMessage" type="IBIS-IP.string"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="DataAcceptedResponseDataStructure">
+		<xs:sequence>
+			<xs:element name="TimeStamp" type="IBIS-IP.dateTime"/>
+			<xs:element name="DataAccepted" type="IBIS-IP.boolean"/>
+			<xs:element name="ErrorCode" type="ErrorCodeEnumeration" minOccurs="0"/>
+			<xs:element name="ErrorInformation" type="IBIS-IP.string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<!--==== GroupDefinitions ====-->
+	<xs:group name="DeviceInformationGroup">
+		<xs:sequence>
+			<xs:element name="DeviceName" type="IBIS-IP.string"/>
+			<xs:element name="Manufacturer" type="IBIS-IP.string"/>
+			<xs:element name="SerialNumber" type="IBIS-IP.NMTOKEN"/>
+			<xs:element name="DeviceClass" type="DeviceClassEnumeration"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="DisplayPolicyGroup">
+		<xs:sequence>
+			<xs:element name="Priority" type="IBIS-IP.nonNegativeInteger" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Value, which allows to decide which Information is shown, if there is not enough time to show all</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PeriodDuration" type="IBIS-IP.duration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>If more than one Sign-Information is given, you need to know</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Duration" type="IBIS-IP.duration" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Time-Value, which defines the part of the Periodtime in which this Sign-Information should be shown</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:group>
+	<xs:complexType name="NetexMode">
+		<xs:annotation>
+			<xs:documentation>a combined Mode and SubMode information in accordance with Netex "netex_submode_version.xsd"</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:choice minOccurs="0">
+				<xs:element name="PtMainMode" type="PtSubModesEnumeration" minOccurs="0"/>
+				<xs:element name="PrivateMainMode" type="PrivateSubModesEnumeration" minOccurs="0"/>
+			</xs:choice>
+			<xs:choice minOccurs="0">
+				<xs:group ref="PtSubmodeChoiceGroup" minOccurs="0"/>
+				<xs:group ref="PrivateSubmodeChoiceGroup" minOccurs="0"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>


### PR DESCRIPTION
This status of the files represents a possible candidate for version 2.4.
I have not made any comparison with the VDV301 documents.
The changes made by Drik Weißer, Florian Kaiser and Thomas Kling were purely merged.

update:
TVS should use enums 2.4
